### PR TITLE
docs: adicionar planos de acao para endpoints mapeados

### DIFF
--- a/docs/action_plans/README.md
+++ b/docs/action_plans/README.md
@@ -1,0 +1,31 @@
+# Planos de Ação – GLPI Dashboard
+
+## Contexto Geral
+- A documentação existente mapeia integrações backend ↔ frontend, porém aponta lacunas em hooks, validação de contratos e cobertura da OpenAPI.【F:docs/endpoints/README.md†L35-L73】
+- Diversos endpoints possuem documentação detalhada mas carecem de implementação completa no frontend (ex.: `/alerts`, `/technician-performance`, `/health`).【F:docs/endpoints/README.md†L37-L47】
+
+## Prioridades Transversais
+1. **Padronização de contratos**  
+   - Implementar estrutura `ApiResponse<T>` compartilhada e validar com Pydantic/Zod conforme recomendado.【F:docs/endpoints/README.md†L75-L113】
+   - Atualizar serviços/hooks para preservar metadados (`cached`, `correlation_id`, `filters_applied`).
+2. **Cobertura OpenAPI + Codegen**  
+   - Expandir `openapi.yaml` para todos os endpoints e automatizar lint/geração de tipos (ver plano específico).【F:docs/endpoints/backend_openapi.md†L16-L164】
+3. **Infra de caching e retries**  
+   - Melhorar estratégia de cache e retry nos clientes (frontend/back) alinhando com recomendações de docs (cache inteligente, TTL adaptativo).【F:docs/endpoints/README.md†L59-L70】
+4. **Feature flags e configuração**  
+   - Sincronizar `.env` e `appConfig` garantindo que variáveis críticas sejam validadas e documentadas.【F:docs/endpoints/frontend_appConfig.md†L48-L200】
+
+## Sequência Recomendada
+1. **Contrato e codegen**: implementar `ApiResponse<T>` + validação, atualizar OpenAPI e gerar tipos.
+2. **Serviços/Hooks críticos**: refatorar `apiService`, `useMetrics`, `useRanking`, `useTickets` para usar contratos atualizados e suportar filtros.
+3. **Novos consumidores**: criar hooks/serviços para `/alerts`, `/technician-performance`, `/health`, `/root`.
+4. **Configuração e infraestrutura**: alinhar `httpClient` e `appConfig`, validar envs, ajustar retries/cache.
+5. **Observabilidade e testes**: adicionar testes pytest/Vitest, métricas de retry/cache e documentação no README principal.
+
+## Artefatos Gerados
+- Planos individuais por endpoint/serviço encontram-se neste diretório (`docs/action_plans/`). Consulte-os para instruções específicas, prompts e validações.
+
+## Próximos Passos
+- Nomear responsáveis por cada plano (ex.: `GLPIDataIngestor` para contratos, `DashboardDesigner` para UI) seguindo prompts sugeridos.
+- Montar cronograma incremental (ex.: Semana 1 – contratos e codegen; Semana 2 – hooks; Semana 3 – endpoints extras; Semana 4 – observabilidade).
+- Acompanhar progresso via checklist compartilhado e validar cada entrega com os testes recomendados.

--- a/docs/action_plans/backend_alerts_plan.md
+++ b/docs/action_plans/backend_alerts_plan.md
@@ -1,0 +1,33 @@
+# Plano de Ação: Endpoint /alerts
+
+## Insights extraídos
+- O endpoint fornece alertas detalhados com filtros por severidade, categoria, limite e possibilidade de incluir resolvidos.【F:docs/endpoints/backend_alerts.md†L14-L99】
+- A resposta contém lista de alertas, resumo agregado e metadados de fonte/cached para uso em dashboards.【F:docs/endpoints/backend_alerts.md†L21-L169】
+- Atualmente o frontend não consome essa rota, apesar de sugerir componentes como `AlertsPanel` ou `NotificationBell`.【F:docs/endpoints/backend_alerts.md†L181-L199】
+
+## Lacunas identificadas
+- Falta serviço/hook no frontend para buscar e exibir alertas com filtragem dinâmica.【F:docs/endpoints/backend_alerts.md†L181-L199】
+- Não existem variáveis de ambiente documentadas no frontend para controlar exibição de alertas (ex.: `VITE_ENABLE_ALERTS`).
+- Ausência de testes garantindo ordenação por severidade e tratamento de alertas resolvidos.
+
+## Próximas ações prioritárias
+1. **Implementar consumo no frontend**  
+   - Adicionar `getAlerts(filters)` em `apiService` retornando `AlertsResponse`, bem como hook `useAlerts` com suporte a filtros reativos e polling configurável.【F:docs/endpoints/backend_alerts.md†L14-L169】
+   - Criar componentes UI (badge no header, painel detalhado) aproveitando campos `summary` e `actions`.
+2. **Configurar feature flags e UX**  
+   - Incluir `VITE_ENABLE_ALERTS` e `VITE_ALERT_POLL_INTERVAL` em `.env.example`, permitindo desligar alertas em ambientes que não suportam o monitoramento.【F:docs/endpoints/backend_alerts.md†L186-L189】
+   - Documentar thresholds e categorias disponíveis no README.
+3. **Cobrir com testes**  
+   - Backend: teste pytest verificando filtros (`severity`, `category`, `include_resolved`) e ordenação por criticidade.【F:docs/endpoints/backend_alerts.md†L14-L69】
+   - Frontend: teste de hook e componente garantindo diferenciação visual por severidade e presença de ações contextuais.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `DashboardDesigner` com foco em alertas proativos.
+> **Objetivo**: Expor alertas dinâmicos no frontend com filtros configuráveis e controles de exibição.
+> **Contexto**: Atualizar `frontend/services/api.ts`, criar `useAlerts` e componentes visuais; ajustar `.env.example` e documentação. Validar backend com testes de filtro/ordenção.
+> **Passos**: (1) Implementar serviço/hook e tipos TS, (2) criar UI para alertas, (3) adicionar feature flag + docs, (4) escrever testes (pytest + React Testing Library).
+
+## Validações recomendadas
+- `pytest backend/tests/unit/test_alerts.py` cobrindo filtros e resumo agregado.
+- `npm run test -- useAlerts` garantindo parsing adequado.
+- Teste manual `curl "http://localhost:5000/api/alerts?severity=high&include_resolved=false"` avaliando resposta e fontes.

--- a/docs/action_plans/backend_health_plan.md
+++ b/docs/action_plans/backend_health_plan.md
@@ -1,0 +1,32 @@
+# Plano de Ação: Endpoint /health
+
+## Insights extraídos
+- Endpoint entrega estado detalhado dos serviços GLPI/Redis e métricas básicas de sistema, porém sem cache e sem tipagem frontend.【F:docs/endpoints/backend_health.md†L16-L177】
+- Recomendação explícita para implementar cache curto, controle de nível de detalhe e documentação OpenAPI.【F:docs/endpoints/backend_health.md†L147-L159】
+
+## Lacunas identificadas
+- O frontend não possui tipo `HealthResponse`, impedindo validação estática do contrato.【F:docs/endpoints/backend_health.md†L79-L111】
+- Requisições repetidas executam verificações completas (sem cache), impactando tempo de resposta em cenários com degradação.【F:docs/endpoints/backend_health.md†L142-L149】
+- Informações sensíveis (uso de memória, tokens) podem ser expostas sem restrição de ambiente.【F:docs/endpoints/backend_health.md†L141-L157】
+
+## Próximas ações prioritárias
+1. **Padronizar contrato**  
+   - Documentar rota `/health` na OpenAPI e criar interface `HealthResponse` em `frontend/types/api.ts` com enums correspondentes.【F:docs/endpoints/backend_health.md†L79-L111】【F:docs/endpoints/backend_health.md†L147-L159】
+   - Expor método `getHealth()` em `apiService` com fallback e testes unitários.
+2. **Adicionar cache e níveis de detalhe**  
+   - Introduzir cache curto (30-60s) usando `cache_with_filters` ou mecanismo equivalente para reduzir carga.【F:docs/endpoints/backend_health.md†L147-L149】
+   - Implementar parâmetro `detail=basic|full` para controlar volume de informações retornadas, restringindo métricas sensíveis em produção.【F:docs/endpoints/backend_health.md†L147-L157】
+3. **Fortalecer observabilidade**  
+   - Registrar eventos de health check no `performance_monitor` e disponibilizar status agregado para integração com `/alerts`.
+   - Criar testes automatizados cobrindo cenários `healthy`, `degraded` e `unhealthy` com e sem cache.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `GLPIDataIngestor` focado em observabilidade.
+> **Objetivo**: Padronizar e proteger o endpoint `/health`, incluindo cache, tipagem e documentação.
+> **Contexto**: Ajustar `backend/api/routes.py`, middleware de cache e `frontend/services/api.ts`/`types/api.ts`; atualizar OpenAPI e documentação de segurança.
+> **Passos**: (1) Criar tipo TS + método `getHealth`, (2) adicionar cache e parâmetro de detalhe no backend, (3) escrever testes pytest cobrindo diferentes estados, (4) atualizar OpenAPI/README.
+
+## Validações recomendadas
+- `pytest backend/tests/unit/test_health.py` validando cenários healthy/unhealthy e cache.
+- `npm run test -- getHealth` (novo) exercitando serviço frontend.
+- Teste manual `curl "http://localhost:5000/api/health?detail=basic"` vs `detail=full` verificando redacted fields.

--- a/docs/action_plans/backend_metrics_plan.md
+++ b/docs/action_plans/backend_metrics_plan.md
@@ -1,0 +1,32 @@
+# Plano de Ação: Endpoint /metrics
+
+## Insights extraídos
+- A documentação descreve resposta envelopada com `success`, `data` e blocos `niveis`, além de metadados de cache e correlação.【F:docs/endpoints/backend_metrics.md†L22-L76】
+- O frontend espera métricas detalhadas (tendências, níveis) via hook dedicado e serviço centralizado.【F:docs/endpoints/backend_metrics.md†L97-L115】【F:docs/endpoints/frontend_useMetrics.md†L9-L63】
+
+## Lacunas identificadas
+- O `apiService.getMetrics` ainda pressupõe estrutura `response.data.data.data`, sinalizando desalinhamento entre contrato documentado e implementação atual.【F:frontend/services/api.ts†L13-L57】
+- A tipagem `DashboardMetrics` usada no hook utiliza campos em maiúsculo (`N1`-`N4`), divergindo do contrato oficial em minúsculo (`n1`-`n4`).【F:docs/endpoints/frontend_useMetrics.md†L25-L63】
+- O appConfig aponta endpoint `/metrics`, mas não provê mecanismos para filtros parametrizados mencionados na documentação (datas, tipos).【F:docs/endpoints/backend_metrics.md†L16-L20】【F:frontend/config/appConfig.ts†L12-L28】
+
+## Próximas ações prioritárias
+1. **Alinhar contrato backend → frontend**  
+   - Ajustar o backend para responder exatamente conforme envelope `success/data` documentado ou adaptar `apiService` para consumir `response.data.data` apenas uma vez, evitando fallback para mocks.【F:docs/endpoints/backend_metrics.md†L22-L76】【F:frontend/services/api.ts†L13-L57】
+   - Atualizar `DashboardMetrics` no frontend para usar as chaves em minúsculo e incluir campo `geral` apenas se vier do backend.
+2. **Suportar filtros**  
+   - Expor parâmetros `start_date`, `end_date` e `filter_type` no serviço (`apiService.getMetrics`) aceitando objeto de filtros e serializando querystring.【F:docs/endpoints/backend_metrics.md†L16-L20】
+   - Criar testes cobrindo filtros no backend (ex.: pytest) e mocks de resposta no frontend.
+3. **Validar contrato com Zod/Pydantic**  
+   - Criar schema Pydantic para saída (`DashboardMetricsResponse`) garantindo presença de campos obrigatórios.【F:docs/endpoints/backend_metrics.md†L149-L155】
+   - No frontend, usar Zod ou utilitário similar para validar payload antes de atualizar o estado.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `GLPIDataIngestor` encarregado de contratos de métricas.
+> **Objetivo**: Eliminar `response.data.data.data`, padronizar chaves de `niveis` e implementar filtros documentados.
+> **Contexto**: Ajuste `backend/api/routes.py` e `GLPIDashboardService` para obedecer ao contrato; atualize `frontend/services/api.ts`, `frontend/types/api.ts` e `useMetrics.ts` para refletir o schema real.
+> **Passos**: (1) Harmonizar resposta do backend, (2) refatorar serviço/hook no frontend, (3) adicionar validações e testes (pytest + Vitest), (4) documentar filtros no README.
+
+## Validações recomendadas
+- `pytest backend/tests/unit/test_metrics.py` (adicionar caso se não existir) para validar envelope.
+- `npm run test -- useMetrics` garantindo que parsing funciona com dados reais.
+- Teste manual `curl "http://localhost:5000/api/metrics?start_date=2025-01-01&filter_type=creation"` e comparar com schema TypeScript.

--- a/docs/action_plans/backend_openapi_plan.md
+++ b/docs/action_plans/backend_openapi_plan.md
@@ -1,0 +1,32 @@
+# Plano de Ação: Endpoint /openapi.yaml
+
+## Insights extraídos
+- Endpoint serve especificação OpenAPI v3 com caminhos principais (`/`, `/metrics`, `/technicians/ranking`), permitindo geração de clientes.【F:docs/endpoints/backend_openapi.md†L16-L164】
+- A documentação destaca necessidade de manter a spec sincronizada com contrato real, incluindo autenticação via header `X-API-Key`.【F:docs/endpoints/backend_openapi.md†L95-L163】
+
+## Lacunas identificadas
+- Spec não cobre todos os endpoints existentes (ex.: `/tickets/new`, `/status`, `/alerts`, `/technician-performance`).
+- Não há pipeline automatizado para validar se o YAML está consistente com código (lint, diff).
+- Frontend não utiliza codegen; tipos são mantidos manualmente, aumentando risco de divergência.
+
+## Próximas ações prioritárias
+1. **Atualizar cobertura da OpenAPI**  
+   - Incluir todos os endpoints documentados nas análises (`/tickets/new`, `/status`, `/health`, `/alerts`, `/technician-performance`, etc.), com parâmetros e respostas correspondentes.【F:docs/endpoints/backend_openapi.md†L51-L163】
+   - Garantir descrição de códigos de erro (`4xx`, `5xx`) e schemas referenciados.
+2. **Automatizar validação**  
+   - Adicionar etapa de CI (ex.: `speccy` ou `openapi-cli`) para lint/validate do arquivo `openapi.yaml`.
+   - Criar teste pytest que verifica existência do arquivo e resposta HTTP correta (`Content-Type` YAML, status 200).
+3. **Integrar com geração de tipos**  
+   - Configurar script (`npm run generate:api`) usando `openapi-typescript` ou similar para gerar tipos TS automaticamente e reduzir manutenção manual.
+   - Documentar processo no README (desenvolvedores devem rodar geração após mudanças na API).
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `GLPIDataIngestor` focado em documentação de API.
+> **Objetivo**: Expandir e validar `openapi.yaml`, cobrindo todos os endpoints e habilitando geração automática de tipos.
+> **Contexto**: Atualizar arquivo `backend/openapi.yaml`, ajustar rota `/openapi.yaml`, configurar scripts NPM/CI para lint/generate.
+> **Passos**: (1) Mapear endpoints faltantes e adicionar ao YAML, (2) configurar ferramentas de validação (CI), (3) integrar codegen no frontend e atualizar README.
+
+## Validações recomendadas
+- Executar `npx @redocly/cli lint backend/openapi.yaml` (ou ferramenta equivalente) localmente e no CI.
+- Rodar script `npm run generate:api` e confirmar que tipos gerados compilaram sem erros.
+- Testar manualmente `curl http://localhost:5000/api/openapi.yaml` verificando cabeçalhos e conteúdo atualizado.

--- a/docs/action_plans/backend_root_plan.md
+++ b/docs/action_plans/backend_root_plan.md
@@ -1,0 +1,31 @@
+# Plano de Ação: Endpoint / (Root)
+
+## Insights extraídos
+- O endpoint raiz apenas fornece metadados da API e hoje não é consumido pelo frontend nem possui tipagem compartilhada.【F:docs/endpoints/backend_root.md†L9-L68】
+
+## Lacunas identificadas
+- O serviço `apiService` não expõe uma chamada `getRoot`, limitando diagnósticos rápidos pela interface.【F:frontend/services/api.ts†L10-L125】
+- O arquivo de tipos não declara a interface `RootResponse`, impossibilitando validação estática do contrato citado na documentação.【F:docs/endpoints/backend_root.md†L30-L43】
+- A especificação OpenAPI carece da rota raiz, dificultando geração automática de clientes.【F:docs/endpoints/backend_root.md†L59-L63】【F:docs/endpoints/backend_openapi.md†L1-L108】
+
+## Próximas ações prioritárias
+1. **Criar tipagem compartilhada**  
+   - Adicionar `RootResponse` em `frontend/types/api.ts` conforme estrutura documentada.【F:docs/endpoints/backend_root.md†L30-L43】
+   - Exportar o tipo para futuros hooks/testes.
+2. **Disponibilizar chamada no serviço**  
+   - Incluir `getRoot()` em `apiService` usando o cliente HTTP padrão, retornando `RootResponse` e reaproveitando tratamento de erro existente.【F:frontend/services/api.ts†L10-L125】
+3. **Automatizar verificação de saúde**  
+   - Criar teste de integração simples (Jest/Vitest) que valide status HTTP 200 e presença de campos obrigatórios.
+4. **Atualizar documentação OpenAPI**  
+   - Inserir a rota `/` no arquivo `openapi.yaml` e garantir exposição pelo endpoint `/openapi.yaml`.
+
+## Prompt sugerido para execução
+> **Identidade**: Você é o agente `GLPIDataIngestor` focado em alinhar contratos REST.
+> **Objetivo**: Implementar o método `getRoot`, tipar `RootResponse` e atualizar `openapi.yaml` com o endpoint raiz.
+> **Contexto**: Use `frontend/services/api.ts` para adicionar o método, `frontend/types/api.ts` para declarar a interface e ajuste o arquivo OpenAPI seguindo o contrato existente.
+> **Passos**: (1) Criar o tipo TS, (2) adicionar método no serviço com tratamento de erro padrão, (3) documentar rota na OpenAPI, (4) escrever teste de integração básico usando Vitest.
+
+## Validações recomendadas
+- Executar `npm run test` no frontend para garantir que novos tipos e testes passam.
+- Realizar `curl http://localhost:5000/api/` e comparar com a interface `RootResponse`.
+- Rodar validação de lint/formatação após ajustes (`npm run lint`).

--- a/docs/action_plans/backend_status_plan.md
+++ b/docs/action_plans/backend_status_plan.md
@@ -1,0 +1,33 @@
+# Plano de Ação: Endpoint /status
+
+## Insights extraídos
+- Endpoint simplificado retorna estado geral com campos `status`, `glpi_status`, `cache_status`, `data_source` e metadados de cache/correlação.【F:docs/endpoints/backend_status.md†L16-L94】
+- O frontend possui método `getSystemStatus`, porém aplica fallbacks genéricos que ignoram `success/cached` e converte resposta em formato alternativo.【F:frontend/services/api.ts†L96-L124】
+- Documentação sugere integração com alertas e melhorias de realtime/histórico.【F:docs/endpoints/backend_status.md†L123-L137】
+
+## Lacunas identificadas
+- Tipagens TypeScript não refletem o envelope (apenas fallback `SystemStatus` sem campos `cached`/`correlation_id`).【F:docs/endpoints/backend_status.md†L60-L94】【F:frontend/services/api.ts†L96-L124】
+- Ausência de hook dedicado com polling configurável; componentes precisam lidar manualmente com loading e erros.【F:docs/endpoints/backend_status.md†L105-L160】
+- Cache fixo de 60s pode mascarar falhas críticas; não há lógica adaptativa baseada em severidade.【F:docs/endpoints/backend_status.md†L123-L137】
+
+## Próximas ações prioritárias
+1. **Alinhar cliente frontend**  
+   - Ajustar `apiService.getSystemStatus` para retornar `SystemStatusResponse` completo, removendo fallback que altera estrutura e expondo `cached`, `correlation_id` e `issues` quando presentes.【F:frontend/services/api.ts†L96-L124】【F:docs/endpoints/backend_status.md†L16-L94】
+   - Criar hook `useSystemStatus` com opções de polling adaptativo (intervalo menor quando degradado/offline).
+2. **Tipagem e UI**  
+   - Definir `SystemStatusResponse` em `frontend/types/api.ts` conforme documentação.【F:docs/endpoints/backend_status.md†L60-L94】
+   - Atualizar componentes do dashboard para exibir badges de severidade, origem dos dados e mensagens de issues.
+3. **Otimizar cache/observabilidade**  
+   - Tornar TTL configurável via `SYSTEM_STATUS_CACHE_TTL` e reduzir automaticamente quando status ≠ `operational`。【F:docs/endpoints/backend_status.md†L110-L137】
+   - Registrar transições de estado em log/alerta para integração com `/alerts`.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `DashboardDesigner` responsável por status operacional.
+> **Objetivo**: Alinhar contrato do endpoint `/status`, exibir indicadores visuais e ajustar cache adaptativo.
+> **Contexto**: Atualizar `frontend/services/api.ts`, criar `useSystemStatus`, modificar componentes do dashboard e ajustar lógica de cache no backend (`backend/api/routes.py`). Documentar novas variáveis (`SYSTEM_STATUS_CACHE_TTL`).
+> **Passos**: (1) Atualizar tipos/serviço, (2) criar hook + UI, (3) implementar cache adaptativo e logs no backend, (4) escrever testes (pytest + React) cobrindo estados operational/degraded/offline.
+
+## Validações recomendadas
+- `pytest backend/tests/unit/test_status.py` cobrindo TTL adaptativo e envelope.
+- `npm run test -- useSystemStatus` validando hook e parsing de issues.
+- Testes manuais alterando `SYSTEM_STATUS_CACHE_TTL` e simulando falhas de GLPI para verificar atualização do front.

--- a/docs/action_plans/backend_technician_performance_plan.md
+++ b/docs/action_plans/backend_technician_performance_plan.md
@@ -1,0 +1,33 @@
+# Plano de Ação: Endpoint /technician-performance
+
+## Insights extraídos
+- A documentação apresenta contrato rico com métricas detalhadas, comparações, tendências e cache de 30 minutos.【F:docs/endpoints/backend_technician_performance.md†L21-L188】
+- O endpoint exige `technician_id` e aceita filtros de período e `include_comparison` para controlar análise.【F:docs/endpoints/backend_technician_performance.md†L14-L55】
+- Atualmente não há consumo no frontend, apesar do potencial para páginas de detalhe e gráficos dedicados.【F:docs/endpoints/backend_technician_performance.md†L178-L200】
+
+## Lacunas identificadas
+- O frontend carece de serviço/hook para buscar dados de performance, inviabilizando uso do endpoint documentado.【F:frontend/services/api.ts†L10-L125】
+- Não existem testes automatizados garantindo cálculo de métricas e comparação com médias, especialmente quando `include_comparison=false`.
+- Falta política clara para exposição de dados sensíveis (ex.: satisfação, rank) e controle de acesso.
+
+## Próximas ações prioritárias
+1. **Disponibilizar consumo frontend**  
+   - Adicionar método `getTechnicianPerformance(params)` em `apiService` aceitando `{ technicianId, startDate, endDate, includeComparison }` e retornando `TechnicianPerformanceResponse` completo.【F:docs/endpoints/backend_technician_performance.md†L14-L166】
+   - Criar hook `useTechnicianPerformance` com suporte a cache local, polling configurável e tratamento de loading/erro.
+2. **Validar cálculos e cache**  
+   - Adicionar testes pytest para cenários com/sem comparação, diferentes períodos e validação de cache TTL (30 min).【F:docs/endpoints/backend_technician_performance.md†L74-L188】
+   - Incluir testes de contrato garantindo presença de campos obrigatórios (metrics, comparison, trends, categories).
+3. **Governança de dados**  
+   - Definir regra de autorização (token ou roles) antes de expor métricas sensíveis; registrar no README de segurança.
+   - Adicionar feature flag (`ENABLE_TECH_PERFORMANCE`) para controlar disponibilidade do endpoint em produção.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `GLPIDataIngestor` especializado em relatórios de performance.
+> **Objetivo**: Habilitar consumo do endpoint `/technician-performance` pelo frontend com contratos validados e políticas de acesso.
+> **Contexto**: Alterar `frontend/services/api.ts`, adicionar novo hook em `frontend/hooks/`, tipagens em `frontend/types/api.ts`, e criar testes (frontend e pytest). Ajustar backend para respeitar feature flag quando necessário.
+> **Passos**: (1) Modelar tipos TS, (2) implementar serviço/hook, (3) criar testes e documentação de segurança, (4) revisar cache TTL.
+
+## Validações recomendadas
+- `pytest backend/tests/unit/test_technician_performance.py` cobrindo parâmetros obrigatórios e opcionais.
+- `npm run test -- useTechnicianPerformance` (novo) validando fluxo no frontend.
+- Teste manual `curl "http://localhost:5000/api/technician-performance?technician_id=123&include_comparison=true"` verificando payload completo.

--- a/docs/action_plans/backend_technicians_ranking_plan.md
+++ b/docs/action_plans/backend_technicians_ranking_plan.md
@@ -1,0 +1,32 @@
+# Plano de Ação: Endpoint /technicians/ranking
+
+## Insights extraídos
+- A rota aceita filtros de data, nível e limite, retornando lista ordenada de técnicos com metadados de cache e correlação.【F:docs/endpoints/backend_technicians_ranking.md†L16-L64】【F:backend/api/routes.py†L687-L840】
+- O frontend consome o endpoint via `apiService.getTechnicianRanking` e hook `useRanking`, porém a interface atual ignora filtros opcionais.【F:frontend/services/api.ts†L60-L74】【F:docs/endpoints/frontend_useRanking.md†L9-L76】
+
+## Lacunas identificadas
+- O serviço frontend não aceita parâmetros estruturados; ele recebe apenas uma string opcional, dificultando uso dos filtros descritos.【F:frontend/services/api.ts†L60-L74】
+- Não há validação TypeScript para o envelope `success/data/cached`, levando o hook a perder informações de metadados (e.g., `filters_applied`).【F:docs/endpoints/backend_technicians_ranking.md†L67-L97】
+- Falta teste automatizado cobrindo o fluxo com filtros e cache (apenas logs mostram execução).【F:backend/api/routes.py†L721-L804】
+
+## Próximas ações prioritárias
+1. **Refatorar cliente frontend**  
+   - Atualizar `getTechnicianRanking` para aceitar objeto de filtros (`{ startDate, endDate, level, entityId, limit }`) e serializá-lo corretamente, preservando envelope completo retornado pelo backend.【F:frontend/services/api.ts†L60-L74】【F:docs/endpoints/backend_technicians_ranking.md†L16-L64】
+   - Ajustar `useRanking` para expor estado de filtros ativos e metadados (`cached`, `filters_applied`).
+2. **Compartilhar contrato**  
+   - Criar tipo `TechnicianRankingResponse` em `frontend/types/api.ts` incluindo `filters_applied` e `correlation_id` conforme documentação.【F:docs/endpoints/backend_technicians_ranking.md†L67-L97】
+   - Garantir que o backend retorne sempre `success`/`data` mesmo quando a lista estiver vazia (já tratado, mas adicionar teste).
+3. **Cobrir com testes e monitoramento**  
+   - Escrever teste pytest que chama `/technicians/ranking` com e sem filtros, validando uso de cache (`cached` true/false) e resposta vazia controlada.【F:backend/api/routes.py†L721-L840】
+   - No frontend, adicionar teste de hook (React Testing Library) simulando resposta com filtros.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `GLPIDataIngestor` com foco em ranking.
+> **Objetivo**: Permitir filtros ricos no ranking de técnicos e alinhar tipagem/contrato.
+> **Contexto**: Trabalhar em `frontend/services/api.ts`, `frontend/hooks/useRanking.ts`, `frontend/types/api.ts` e testes correspondentes; complementar com teste pytest em `backend/tests/`.
+> **Passos**: (1) Modelar DTO de filtros, (2) refatorar serviço/hook, (3) criar testes (frontend + backend), (4) atualizar documentação de uso de filtros no README.
+
+## Validações recomendadas
+- `pytest backend/tests/unit/test_ranking.py` (criar se inexistente) cobrindo filtros e cache.
+- `npm run test -- useRanking` para garantir que hook consome novo contrato.
+- Teste manual `curl "http://localhost:5000/api/technicians/ranking?level=N1&limit=5"` comparando com resposta tipada.

--- a/docs/action_plans/backend_tickets_new_plan.md
+++ b/docs/action_plans/backend_tickets_new_plan.md
@@ -1,0 +1,32 @@
+# Plano de Ação: Endpoint /tickets/new
+
+## Insights extraídos
+- A rota suporta filtros (`limit`, `status`, `priority`, `assigned_to`) e retorna envelope com `total_count`, `filters_applied` e metadados de cache.【F:docs/endpoints/backend_tickets_new.md†L16-L79】
+- O frontend consome o endpoint via `apiService.getNewTickets` e hook `useTickets`, com refresh automático de 45s.【F:frontend/services/api.ts†L77-L93】【F:docs/endpoints/frontend_useTickets.md†L9-L68】
+
+## Lacunas identificadas
+- O serviço frontend envia apenas `limit`, ignorando filtros adicionais descritos no contrato, o que dificulta reproduzir cenários reais durante análises.【F:frontend/services/api.ts†L77-L93】【F:docs/endpoints/backend_tickets_new.md†L16-L79】
+- Não há paginação implementada (cursor/offset) apesar da recomendação explícita, podendo sobrecarregar o frontend com listas grandes.【F:docs/endpoints/backend_tickets_new.md†L159-L177】
+- Dados sensíveis (e-mail do solicitante) são entregues diretamente ao frontend sem ofuscação ou consentimento explícito.【F:docs/endpoints/backend_tickets_new.md†L35-L63】
+
+## Próximas ações prioritárias
+1. **Ampliar filtros no cliente**  
+   - Atualizar `apiService.getNewTickets` para aceitar objeto de filtros (status, priority, technician, date range) e refletir `filters_applied` na resposta do hook.【F:frontend/services/api.ts†L77-L93】【F:docs/endpoints/backend_tickets_new.md†L16-L79】
+   - Adaptar `useTickets` para receber opções (intervalo de refresh customizado, filtros dinâmicos) e propagar metadados (total_count, cached).
+2. **Implementar paginação segura**  
+   - Introduzir suporte a paginação por cursor/offset no backend (`/tickets/new`) e expor parâmetros (`page`, `cursor`, `page_size`) devidamente validados.【F:docs/endpoints/backend_tickets_new.md†L159-L177】
+   - Ajustar hook/componente para lidar com carregamento incremental (infinite scroll ou paginação tradicional).
+3. **Tratar dados sensíveis**  
+   - Avaliar necessidade de mascarar ou omitir e-mails no payload, expondo apenas domínio ou inicial quando requerido.【F:docs/endpoints/backend_tickets_new.md†L35-L63】【F:docs/endpoints/backend_tickets_new.md†L165-L176】
+   - Documentar política de privacidade e adicionar testes garantindo que ofuscação ocorre quando habilitada.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `GLPIDataIngestor` responsável por tickets recentes.
+> **Objetivo**: Suportar filtros completos, paginação e proteção de dados sensíveis nos tickets novos.
+> **Contexto**: Alterar `backend/api/routes.py`, serviços de tickets e `frontend/services/api.ts`/`useTickets.ts`; atualizar `frontend/types/api.ts` com envelope `NewTicketsResponse` completo.
+> **Passos**: (1) Estender filtros e paginação no backend, (2) refletir mudanças no frontend, (3) mascarar e-mails conforme configuração, (4) criar testes (pytest + React Testing Library) e atualizar documentação.
+
+## Validações recomendadas
+- `pytest backend/tests/unit/test_tickets_new.py` cobrindo filtros, paginação e mascaramento.
+- `npm run test -- useTickets` validando comportamento do hook com novos filtros.
+- Teste manual `curl "http://localhost:5000/api/tickets/new?status=new&priority=high&limit=5"` verificando `filters_applied` e ofuscação.

--- a/docs/action_plans/frontend_apiService_plan.md
+++ b/docs/action_plans/frontend_apiService_plan.md
@@ -1,0 +1,32 @@
+# Plano de Ação: Serviço apiService
+
+## Insights extraídos
+- Documentação descreve métodos simples (`getMetrics`, `getTechnicianRanking`, `getNewTickets`, `getSystemStatus`) utilizando `httpClient` diretamente.【F:docs/endpoints/frontend_apiService.md†L13-L124】
+- Implementação atual usa `httpClientWithRetry`, trata envelopes incompletos (ex.: `response.data.data.data`) e retorna estruturas parciais com fallbacks mock.【F:frontend/services/api.ts†L10-L154】
+
+## Lacunas identificadas
+- Serviço não reutiliza um tipo genérico `ApiResponse<T>`, resultando em parsing manual e risco de divergência entre endpoints.【F:frontend/services/api.ts†L10-L154】
+- Métodos carecem de suporte a parâmetros ricos (objetos vs string query) e descartam metadados (`cached`, `correlation_id`).【F:frontend/services/api.ts†L60-L123】
+- Ausência de métodos para novos endpoints (`/alerts`, `/technician-performance`, `/health`, `/root`), dificultando expansão futura.【F:docs/endpoints/backend_alerts.md†L181-L199】【F:docs/endpoints/backend_technician_performance.md†L178-L200】
+
+## Próximas ações prioritárias
+1. **Centralizar parsing e envelopes**  
+   - Criar utilitário `extractData<T>(response: ApiResponse<T>)` que valida presença de `success`/`data` e lança erro se contrato inválido, eliminando verificações aninhadas.【F:frontend/services/api.ts†L10-L154】
+   - Usar generics com `ApiResponse<T>` em todos os métodos, preservando metadados nas respostas.
+2. **Expandir cobertura de endpoints**  
+   - Adicionar métodos para `/alerts`, `/technician-performance`, `/health`, `/openapi.yaml`, `/config/migration`, entre outros documentados, retornando tipos específicos.【F:docs/endpoints/backend_alerts.md†L14-L199】【F:docs/endpoints/backend_technician_performance.md†L14-L188】【F:docs/endpoints/backend_health.md†L16-L177】
+   - Converter parâmetros para objetos (ex.: `getTechnicianRanking(filters: RankingFilters)`), serializando internamente.
+3. **Padronizar tratamento de erros e retries**  
+   - Consolidar lógica de fallback (ex.: métricas mock) em um módulo separado para evitar replicação.
+   - Registrar métricas de falha/sucesso por endpoint para futura observabilidade.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `GLPIDataIngestor` responsável pelo cliente REST.
+> **Objetivo**: Refatorar `apiService` para usar envelopes padronizados, suportar novos endpoints e preservar metadados.
+> **Contexto**: Trabalhar em `frontend/services/api.ts`, `frontend/types/api.ts`, utilitários de querystring e testes; integrar novos métodos aos hooks correspondentes.
+> **Passos**: (1) Introduzir `ApiResponse<T>` genérico, (2) refatorar métodos existentes e adicionar endpoints faltantes, (3) criar testes unitários para cada método, (4) atualizar documentação de uso.
+
+## Validações recomendadas
+- `npm run test -- apiService` cobrindo parsing de envelopes e erros.
+- Verificação manual via Storybook/Playground para cada método novo.
+- Monitorar logs para confirmar que retrys (`httpClientWithRetry`) permanecem funcionais após refatoração.

--- a/docs/action_plans/frontend_appConfig_plan.md
+++ b/docs/action_plans/frontend_appConfig_plan.md
@@ -1,0 +1,32 @@
+# Plano de Ação: appConfig
+
+## Insights extraídos
+- Documento recomenda centralizar configurações de API, cache, refresh e feature flags, além de validar variáveis obrigatórias.【F:docs/endpoints/frontend_appConfig.md†L15-L200】
+- Implementação atual em `appConfig.ts` combina `API_CONFIG` (do httpClient) com `ENV_CONFIG`, mas mantém endpoints hardcoded (ex.: `/ranking`, `/tickets`) que não correspondem às rotas reais do backend.【F:frontend/config/appConfig.ts†L12-L101】
+
+## Lacunas identificadas
+- Endpoints definidos (`ranking: '/ranking'`, `tickets: '/tickets'`) não refletem caminhos reais (`/technicians/ranking`, `/tickets/new`), causando URLs incorretas se `getApiUrl` for usado diretamente.【F:frontend/config/appConfig.ts†L12-L101】
+- Validação de variáveis obrigatórias (ex.: `VITE_API_BASE_URL`) não ocorre; fallback default pode mascarar erro de configuração.【F:docs/endpoints/frontend_appConfig.md†L48-L200】
+- Feature flags/documentação `.env.example` não estão sincronizadas com necessidades atuais (alertas, performance, mocks).
+
+## Próximas ações prioritárias
+1. **Revisar mapa de endpoints**  
+   - Atualizar `endpointsConfig` para refletir rotas reais (`/technicians/ranking`, `/tickets/new`, `/alerts`, etc.) e incluir funções helper específicas (ex.: `getApiUrl('techniciansRanking')`).【F:frontend/config/appConfig.ts†L12-L101】
+   - Garantir que `getApiUrl` não duplique `/api` quando `VITE_API_BASE_URL` já inclui o prefixo.
+2. **Validar variáveis de ambiente**  
+   - Implementar função `validateConfig()` lançando erro claro quando variáveis obrigatórias estiverem ausentes, conforme sugerido na documentação.【F:docs/endpoints/frontend_appConfig.md†L96-L200】
+   - Adicionar `.env.example` atualizado com todas as chaves necessárias (API, retries, alertas, performance, toggles de mock).
+3. **Consolidar feature flags**  
+   - Agrupar flags (`enableRealTimeUpdates`, `enableNotifications`, `enableMocks`) em objeto único e sincronizar com componentes que usam essas flags.
+   - Documentar impacto de cada flag no README.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `DashboardDesigner` encarregado de configurações de frontend.
+> **Objetivo**: Corrigir endpoints, validar variáveis e alinhar feature flags em `appConfig`.
+> **Contexto**: Atualizar `frontend/config/appConfig.ts`, criar/ajustar `.env.example`, revisar componentes que utilizam `getApiUrl` e feature flags.
+> **Passos**: (1) Corrigir `endpointsConfig` e helpers, (2) adicionar validação de env + mensagens claras, (3) atualizar documentação/env de exemplo, (4) ajustar consumidores (serviços/hooks).
+
+## Validações recomendadas
+- Executar `npm run build` para garantir que `appConfig` não lança erros em produção.
+- Teste manual verificando `getApiUrl('techniciansRanking')` e `getApiUrl('ticketsNew')` tanto em dev quanto build.
+- Revisar Storybook/Playground para confirmar que feature flags afetam componentes esperados.

--- a/docs/action_plans/frontend_httpClient_plan.md
+++ b/docs/action_plans/frontend_httpClient_plan.md
@@ -1,0 +1,32 @@
+# Plano de Ação: Cliente HTTP (httpClient.ts)
+
+## Insights extraídos
+- Cliente atual define `BASE_URL` dinamicamente (`/api` em desenvolvimento, `VITE_API_BASE_URL` em produção) e configura retries com backoff manual.【F:frontend/services/httpClient.ts†L14-L99】
+- Documentação enfatiza interceptadores para logging, enriquecimento de erros e cabeçalhos adicionais.【F:docs/endpoints/frontend_httpClient.md†L27-L183】
+
+## Lacunas identificadas
+- Configuração duplicada entre `httpClient.ts` (usa `API_CONFIG`) e `appConfig.api` (espera `apiUrl`), podendo gerar inconsistência de base URL.【F:frontend/services/httpClient.ts†L14-L58】【F:frontend/config/appConfig.ts†L6-L85】
+- Retries são implementados manualmente mas não respeitam cabeçalhos `Retry-After` nem exibem jitter configurável, mesmo após melhorias recentes no backend.【F:frontend/services/httpClient.ts†L60-L104】
+- Logs condicionados a `process.env.NODE_ENV` (API do Vite) podem não funcionar em build ESM; recomendável usar `import.meta.env`.
+
+## Próximas ações prioritárias
+1. **Unificar fonte da base URL**  
+   - Centralizar cálculo da base URL em `appConfig` e reutilizar no cliente HTTP (evitar divergência entre `API_CONFIG.BASE_URL` e `appConfig.api.BASE_URL`).【F:frontend/services/httpClient.ts†L14-L38】【F:frontend/config/appConfig.ts†L12-L99】
+   - Garantir suporte a caminhos relativos quando `VITE_API_BASE_URL` inclui `/api` explícito.
+2. **Melhorar estratégia de retry**  
+   - Respeitar cabeçalhos `Retry-After` e incluir jitter exponencial configurável via env (`VITE_API_RETRY_*`).【F:frontend/services/httpClient.ts†L60-L104】
+   - Registrar métricas de tentativa (`retryCount`) para observabilidade.
+3. **Higienizar logging e headers**  
+   - Trocar `process.env.NODE_ENV` por `import.meta.env.DEV/PROD` para compatibilidade com Vite.【F:frontend/services/httpClient.ts†L32-L52】
+   - Permitir injeção opcional de header `X-Correlation-ID` (gerado no front) para rastrear chamadas.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `GLPIDataIngestor` focado em infraestrutura de cliente HTTP.
+> **Objetivo**: Consolidar configuração do `httpClient`, aprimorar retries e alinhar logging com Vite.
+> **Contexto**: Atualizar `frontend/services/httpClient.ts` e `frontend/config/appConfig.ts`; revisar uso em `apiService` e hooks.
+> **Passos**: (1) Criar utilitário único para base URL, (2) implementar retry com jitter/Retry-After, (3) ajustar logs/headers e adicionar testes.
+
+## Validações recomendadas
+- `npm run test -- httpClient` exercitando interceptadores e retries com mocks (ex.: axios-mock-adapter).
+- Teste manual no browser verificando base URL correta tanto em dev (proxy `/api`) quanto em build (`VITE_API_BASE_URL`).
+- Monitorar console para garantir logs controlados e presença de `X-Correlation-ID` quando habilitado.

--- a/docs/action_plans/frontend_useMetrics_plan.md
+++ b/docs/action_plans/frontend_useMetrics_plan.md
@@ -1,0 +1,33 @@
+# Plano de Ação: Hook useMetrics
+
+## Insights extraídos
+- Hook atual busca métricas, controla loading/error e faz refresh a cada 30s.【F:docs/endpoints/frontend_useMetrics.md†L9-L63】
+- Tipagem interna usa chaves `N1`-`N4`, diferindo do contrato backend (`n1`-`n4`).【F:docs/endpoints/frontend_useMetrics.md†L25-L63】
+- Estrutura do hook não expõe metadados (`cached`, `correlation_id`, `tendencias`) além do objeto principal.【F:frontend/services/api.ts†L13-L57】
+
+## Lacunas identificadas
+- Hook depende de `apiService.getMetrics` que retorna fallback mock quando não encontra `response.data.data.data`, mascarando inconsistências de contrato.【F:frontend/services/api.ts†L13-L57】
+- Falta suporte a filtros (datas, tipos) mesmo sendo previstos pela API, e o interval fixo não considera o volume de dados.【F:docs/endpoints/backend_metrics.md†L16-L20】【F:docs/endpoints/frontend_useMetrics.md†L41-L63】
+- Ausência de cache local (ex.: React Query) e invalidação manual dificulta reutilização em múltiplos componentes.
+
+## Próximas ações prioritárias
+1. **Realinhar tipagem e parsing**  
+   - Atualizar tipo `DashboardMetrics` para chaves em minúsculo e incluir opcional `geral`, `tendencias`, `metadata` (cached, correlation).【F:docs/endpoints/backend_metrics.md†L22-L115】
+   - Ajustar hook para receber objeto `ApiResponse<DashboardMetrics>` e expor metadados separados.
+2. **Adicionar suporte a filtros**  
+   - Permitir `useMetrics({ startDate, endDate, filterType })`, repassando ao serviço e recalculando interval de refresh conforme configuração do usuário.【F:docs/endpoints/backend_metrics.md†L16-L20】
+   - Implementar memorização via `useMemo`/`useRef` para evitar refetchs desnecessários.
+3. **Melhorar resiliência**  
+   - Integrar com biblioteca de data fetching (TanStack Query/SWR) ou construir cache manual com TTL configurável.
+   - Expor estado `source` (GLPI vs mock) e `lastUpdated` para UI mostrar badges de confiabilidade.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `DashboardDesigner` encarregado das métricas.
+> **Objetivo**: Atualizar `useMetrics` para consumir o contrato real, suportar filtros e expor metadados completos.
+> **Contexto**: Modificar `frontend/hooks/useMetrics.ts`, `frontend/services/api.ts`, `frontend/types/api.ts` e testes relacionados.
+> **Passos**: (1) Refatorar serviço para retornar envelope correto, (2) atualizar hook com opções de filtros e metadados, (3) adicionar testes com dados reais/mocks, (4) documentar uso no README.
+
+## Validações recomendadas
+- `npm run test -- useMetrics` cobrindo novos casos de filtros e metadados.
+- Storybook ou playground exibindo badges de fonte (GLPI/Mock) e timestamp atualizado.
+- Teste manual com `curl` comparando resposta `/metrics` e dados apresentados pelo hook.

--- a/docs/action_plans/frontend_useRanking_plan.md
+++ b/docs/action_plans/frontend_useRanking_plan.md
@@ -1,0 +1,32 @@
+# Plano de Ação: Hook useRanking
+
+## Insights extraídos
+- Hook atual realiza fetch a cada 60s, mas não aceita filtros nem retorna metadados de cache/correlação.【F:docs/endpoints/frontend_useRanking.md†L9-L87】
+- O contrato backend prevê filtros (`limit`, `start_date`, `end_date`, `level`, `entity_id`) e campos adicionais na resposta.【F:docs/endpoints/backend_technicians_ranking.md†L16-L97】
+
+## Lacunas identificadas
+- `useRanking` chama serviço sem parâmetros estruturados, impossibilitando explorar filtros avançados do backend.【F:frontend/services/api.ts†L60-L74】
+- Hook não expõe `filters_applied`, `cached` ou `correlation_id`, impedindo UI de exibir contexto da consulta.【F:docs/endpoints/backend_technicians_ranking.md†L67-L97】
+- Intervalo fixo de 60s não considera cenários de degradação ou dashboards em background.
+
+## Próximas ações prioritárias
+1. **Adicionar suporte a filtros e metadados**  
+   - Atualizar hook para receber objeto `{ filters, refreshInterval }`, invocar serviço com querystring gerada a partir de filtros e armazenar `response.metadata` separadamente.【F:docs/endpoints/backend_technicians_ranking.md†L16-L97】【F:frontend/services/api.ts†L60-L74】
+   - Expor `setFilters` ou método `updateFilters` para permitir interação via UI.
+2. **Integração com caching e estados**  
+   - Considerar uso de TanStack Query/SWR para caching e refetch automático ao focar a aba.
+   - Incluir fallback visual quando `is_mock_data` estiver true.
+3. **Testes e documentação**  
+   - Criar testes de hook verificando atualização ao mudar filtros, tratamento de erros e exibição de ranking vazio.
+   - Atualizar README com exemplos de uso (combinação com dropdowns de nível/entidade).
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `DashboardDesigner` para ranking de técnicos.
+> **Objetivo**: Permitir filtros ricos, metadados e caching no `useRanking`.
+> **Contexto**: Refatorar `frontend/hooks/useRanking.ts`, `frontend/services/api.ts` e tipos associados; adicionar testes.
+> **Passos**: (1) Ajustar serviço/hook para aceitar filtros, (2) expor metadados, (3) integrar com caching adaptativo, (4) documentar e testar.
+
+## Validações recomendadas
+- `npm run test -- useRanking` com cenários de filtros e erro de rede.
+- UI manual exibindo ranking filtrado por nível/entidade.
+- Monitorar logs do backend para garantir que filtros estão chegando corretamente (`[ROUTES DEBUG]`).

--- a/docs/action_plans/frontend_useTickets_plan.md
+++ b/docs/action_plans/frontend_useTickets_plan.md
@@ -1,0 +1,32 @@
+# Plano de Ação: Hook useTickets
+
+## Insights extraídos
+- Hook faz polling a cada 45s e retorna lista de tickets novos sem suporte a filtros avançados.【F:docs/endpoints/frontend_useTickets.md†L9-L88】
+- Contrato backend inclui campos `total_count`, `filters_applied`, `cached` e metadados de origem.【F:docs/endpoints/backend_tickets_new.md†L23-L127】
+
+## Lacunas identificadas
+- Hook/serviço retornam apenas array de tickets, descartando `total_count`, `cached` e `correlation_id` necessários para UX e debugging.【F:frontend/services/api.ts†L77-L93】【F:docs/endpoints/backend_tickets_new.md†L23-L127】
+- Não há forma de aplicar filtros (status, priority, date range) a partir do frontend, embora documentados no backend.【F:docs/endpoints/backend_tickets_new.md†L16-L79】【F:docs/endpoints/frontend_useTickets.md†L25-L68】
+- Falta estratégia de paginação/infinite scroll; hook sempre substitui lista inteira.
+
+## Próximas ações prioritárias
+1. **Alinhar contrato de resposta**  
+   - Atualizar serviço/hook para retornar objeto `{ tickets, totalCount, cached, filtersApplied, correlationId }`, preservando dados de origem (`data_source`, `is_mock_data`).【F:docs/endpoints/backend_tickets_new.md†L23-L127】
+   - Expor `setFilters` no hook, permitindo ajustes dinâmicos (status, priority, technician, limit).
+2. **Paginação e UX**  
+   - Implementar paginação incremental (cursor/offset) no hook e nos componentes, reduzindo carga inicial.【F:docs/endpoints/backend_tickets_new.md†L159-L177】
+   - Adicionar indicadores visuais para fonte de dados, SLA restante e badges de prioridade.
+3. **Testes e monitoramento**  
+   - Criar testes de hook simulando mudanças de filtros, paginação e falhas de rede.
+   - Documentar processos de ofuscação de dados sensíveis (e-mail) e validar via testes.
+
+## Prompt sugerido para execução
+> **Identidade**: Agente `DashboardDesigner` orientado a tickets.
+> **Objetivo**: Estender `useTickets` para suportar filtros/paginação e preservar metadados do backend.
+> **Contexto**: Ajustar `frontend/services/api.ts`, `frontend/hooks/useTickets.ts`, componentes do dashboard e tipos TS; alinhar com mudanças no backend (`/tickets/new`).
+> **Passos**: (1) Atualizar serviço e hook, (2) implementar paginação e UI correspondente, (3) adicionar testes, (4) documentar novas props/variáveis.
+
+## Validações recomendadas
+- `npm run test -- useTickets` cobrindo filtros, paginação e erros.
+- Teste manual com `curl` e comparação da UI (contagem total vs exibida).
+- Monitorar logs de backend para validar recebimento de filtros/paginação.


### PR DESCRIPTION
## Summary
- adicionar diretório `docs/action_plans` com plano geral e instruções específicas por endpoint/serviço
- detalhar próximos passos para métricas, ranking, tickets, status, alerts e componentes frontend correspondentes
- registrar prompts sugeridos, validações recomendadas e requisitos de configuração para execução das correções

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c7824b01ec83209060e422a766bf37