### PR TITLE
docs: validar blueprint e definir prompt orquestrador

### DIFF
--- a/docs/AUDITORIA_ARQUITETURA_CONSISTENCIA.md
+++ b/docs/AUDITORIA_ARQUITETURA_CONSISTENCIA.md
@@ -1,0 +1,85 @@
+# Auditoria de Arquitetura e Consistência – GLPI Dashboard
+
+## 1. Contexto e Objetivo
+Esta auditoria foi conduzida para validar a base arquitetural antes da execução dos planos descritos em `docs/action_plans`, garantindo que não existam dívidas estruturais capazes de perpetuar erros difíceis de rastrear. O foco abrange backend (Flask + Clean Architecture híbrida), frontend (React + Vite) e a cadeia de ingestão de dados do GLPI, com especial atenção à montagem de _criteria_ na API do GLPI.
+
+Referências centrais:
+- Diretrizes transversais dos planos de ação que priorizam padronização de contratos, OpenAPI, caching e alinhamento de configuração.【F:docs/action_plans/README.md†L1-L31】
+- Componentes críticos do backend (`MetricsFacade`, adapters legados e serviços GLPI).【F:backend/core/application/services/metrics_facade.py†L1-L199】【F:backend/core/infrastructure/adapters/legacy_service_adapter.py†L1-L200】【F:backend/services/legacy/glpi_service_facade.py†L1-L200】
+- Serviços do frontend responsáveis por contratos e consumo de dados.【F:frontend/services/api.ts†L1-L155】【F:frontend/types/api.ts†L1-L99】【F:frontend/services/httpClient.ts†L1-L179】
+
+## 2. Visão Atual da Arquitetura
+### 2.1 Backend
+- **Ponto de entrada**: Flask `app.py` realiza configuração de logging, CORS e registra _blueprints_.【F:backend/app.py†L1-L45】
+- **Configuração**: `config/settings.py` concentra validações robustas de variáveis de ambiente, _feature flags_ (`USE_LEGACY_SERVICES`, `USE_MOCK_DATA`) e parâmetros de observabilidade.【F:backend/config/settings.py†L1-L200】
+- **Camada de aplicação**: `MetricsFacade` decide dinamicamente entre `LegacyServiceAdapter` (serviços GLPI herdados) e `GLPIMetricsAdapter`, mantendo contratos síncronos para Flask, porém invocando lógica assíncrona e cache unificado.【F:backend/core/application/services/metrics_facade.py†L1-L199】
+- **Camada legacy**: `LegacyServiceAdapter` encapsula _retry_, monitoramento e conversão de dados consumindo `GLPIServiceFacade`, o qual ainda expõe a interface monolítica antiga através de serviços decompondo autenticação, cache e montagem de _criteria_.【F:backend/core/infrastructure/adapters/legacy_service_adapter.py†L1-L200】【F:backend/services/legacy/glpi_service_facade.py†L1-L200】
+- **Cache**: `UnifiedCache` mantém cache em memória com TTL e estatísticas básicas, porém sem isolamento por processo (risco em ambientes com múltiplos workers).【F:backend/core/infrastructure/cache/unified_cache.py†L1-L118】
+- **Consultas GLPI**: `metrics_service.py` e serviços correlatos continuam construindo manualmente estruturas `criteria`/`metacriteria` para filtros finos (datas, níveis, prioridades), exigindo preservação cuidadosa dessas regras em qualquer refatoração.【F:backend/services/legacy/metrics_service.py†L73-L158】
+
+### 2.2 Frontend
+- **Configuração**: `httpClient.ts` aplica axios com _retry_, placeholders de autenticação e descoberta automática de baseURL, enquanto `appConfig.ts` replica endpoints e _feature flags_ de forma estática.【F:frontend/services/httpClient.ts†L1-L179】【F:frontend/config/appConfig.ts†L1-L101】
+- **Contratos**: Tipagens em `types/api.ts` esperam objetos completos (ex.: `DashboardMetrics` com totais, `data_source`, `is_mock_data`).【F:frontend/types/api.ts†L1-L99】
+- **Serviços/Hooks**: `apiService` converte manualmente respostas aninhadas (`response.data.data.data`), aplica _fallbacks_ para dados mockados e ignora metadados de execução; hooks (`useMetrics`, `useRanking`, `useTickets`) apenas _polling_ os endpoints e não propagam filtros ou estado avançado.【F:frontend/services/api.ts†L1-L155】【F:frontend/hooks/useMetrics.ts†L1-L35】
+
+## 3. Principais Inconsistências e Dívidas Técnicas
+### 3.1 Convivência de Clean Architecture e legado
+- `MetricsFacade` mantém bifurcação via `USE_LEGACY_SERVICES`, mas apenas inicializa `query_factory` quando usa o adapter novo; na opção legacy, toda a lógica permanece síncrona, causando duplicação de contratos e tratamentos de erro.【F:backend/core/application/services/metrics_facade.py†L41-L168】
+- `LegacyServiceAdapter` adiciona _retry_, log estruturado e conversão, porém retorna diretamente `ApiResponse` (Pydantic) do legado, conflitando com expectativa de DTOs no domínio limpo e dificultando substituição progressiva.【F:backend/core/infrastructure/adapters/legacy_service_adapter.py†L69-L179】
+
+### 3.2 Complexidade desnecessária na camada legacy
+- `GLPIServiceFacade` reconstrói uma “mini arquitetua” interna (auth/cache/http/metrics/trends) mantendo a mesma interface monolítica, resultando em acoplamento forte e repetição de logs/cache em múltiplos níveis.【F:backend/services/legacy/glpi_service_facade.py†L21-L195】
+- Lógicas de _criteria_ GLPI estão espalhadas entre `metrics_service`, `glpi_service_facade` e adaptadores, elevando risco de regressões quando filtros são ajustados.【F:backend/services/legacy/metrics_service.py†L73-L158】
+
+### 3.3 Contratos inconsistentes entre camadas
+- Frontend espera `DashboardMetrics` com campo `total`, `timestamp`, `data_source`, mas `apiService.getMetrics` monta um objeto incompleto e adiciona `niveis.geral`, divergindo do schema Pydantic que separa níveis (`N1..N4`) e totals já calculados.【F:frontend/services/api.ts†L15-L155】【F:frontend/types/api.ts†L16-L42】
+- Respostas do backend embrulham dados em múltiplos níveis (`response.data.data.data`), indicando ausência de padronização `ApiResponse<T>` e validação automática mencionadas nos planos de ação.【F:frontend/services/api.ts†L11-L57】【F:docs/action_plans/README.md†L7-L23】
+
+### 3.4 Configuração e _feature flags_ duplicadas
+- `config/settings.py` controla `USE_MOCK_DATA`/`USE_LEGACY_SERVICES`, enquanto `appConfig.ts` e `httpClient.ts` mantêm lógica paralela de _mocks_, _retry_ e endpoints; sem sincronização automática, configurações podem divergir entre ambientes.【F:backend/config/settings.py†L78-L133】【F:frontend/services/httpClient.ts†L1-L179】【F:frontend/config/appConfig.ts†L1-L101】
+
+### 3.5 Observabilidade e testes
+- Middleware de observabilidade é registrado, mas faltam métricas específicas para diferenciar caminho legacy vs. novo e não há testes automatizados para garantir o contrato `ApiResponse` nas rotas.
+- Hooks do frontend não expõem telemetria (ex.: tempo de resposta, erro cumulativo), inviabilizando diagnóstico rápido quando cache ou filtros quebram.【F:frontend/hooks/useMetrics.ts†L1-L35】
+
+## 4. Recomendações de Reestruturação
+### 4.1 Roadmap incremental (preservando _criteria_ GLPI)
+1. **Estabilizar contratos**: aplicar `ApiResponse<T>` único no backend (camada Flask) e ajustar `apiService` para ler apenas `response.data` + metadados, eliminando o triplo `data` e garantindo validação Pydantic/Zod conforme plano transversal.【F:frontend/services/api.ts†L11-L57】【F:docs/action_plans/README.md†L7-L23】
+2. **Faixa anti-regressão de critérios**: encapsular montagens de `criteria` em serviços reutilizáveis (ex.: `glpi_query_builder.py`) com testes unitários baseados nas combinações críticas vistas em `metrics_service`, evitando duplicidade em adapters.【F:backend/services/legacy/metrics_service.py†L73-L158】
+3. **Camada de orquestração**: redefinir `MetricsFacade` para sempre retornar DTOs do domínio, delegando conversão de `ApiResponse` ao controller Flask. Criar _feature flag_ apenas para selecionar o _data source_ (legacy x GLPI direto) sem alterar contrato.【F:backend/core/application/services/metrics_facade.py†L41-L199】
+4. **Adapter simplificado**: evoluir `LegacyServiceAdapter` para expor métodos mínimos (`fetch_metrics`, `fetch_tickets`, etc.) que retornem estruturas primitivas, deixando mapeamento Pydantic na camada de aplicação.【F:backend/core/infrastructure/adapters/legacy_service_adapter.py†L69-L179】
+5. **Frontend alinhado**: gerar tipos a partir da OpenAPI atualizada, atualizar `apiService`/hooks para propagar filtros (datas, níveis, prioridade) e armazenar metadados (correlationId, cache hit) para observabilidade no dashboard.【F:frontend/services/api.ts†L11-L155】【F:frontend/hooks/useMetrics.ts†L1-L35】
+
+### 4.2 Opção de reescrita controlada
+Caso se opte por reescrever o backend:
+- Definir módulos explícitos (`glpi_client`, `metrics_repository`, `metrics_service`, `dashboard_api`) e mover a lógica de _criteria_ intacta para uma camada `query_builders`, garantindo paridade com `metrics_service` existente antes de desmontar o legado.【F:backend/services/legacy/metrics_service.py†L73-L158】
+- Implementar _ports/adapters_ simples (FastAPI/Flask) usando testes de aceitação contra o GLPI real ou _fixtures_ gravadas para não quebrar filtros.
+- Manter `USE_MOCK_DATA` como _feature flag_ de fallback até que a nova cadeia esteja validada em produção limitada.【F:backend/config/settings.py†L78-L90】
+
+### 4.3 Simplificação de configuração
+- Consolidar configurações em um manifesto (ex.: `config/runtime_settings.json`) gerado a partir de variáveis de ambiente e consumido pelo frontend, eliminando divergência entre `appConfig.ts` e backend.
+- Expor endpoint `/config/runtime` autenticado que devolva flags ativas e limites de cache, alimentando o dashboard de observabilidade.
+
+## 5. Automação e Governança Recomendadas
+1. **Lint + Formatação**: aplicar `ruff`/`black` no backend e `eslint`/`prettier` no frontend para evitar deriva estrutural.
+2. **Testes de contrato**: criar suíte pytest que chama endpoints e valida modelos Pydantic (ex.: `ApiResponse[DashboardMetrics]`), além de testes Vitest para `apiService`/hooks com _fixtures_ simulando respostas GLPI.【F:frontend/services/api.ts†L11-L155】
+3. **Testes arquiteturais**: usar `pytest-arch` ou `import-linter` para garantir dependências unidirecionais (ex.: `core.domain` não pode importar `services.legacy`).
+4. **CI/CD**: pipeline com etapas de lint, testes, geração de OpenAPI e _schema diff_ (falha se modelos divergirem). Incluir etapa que roda consultas GLPI com _criteria_ conhecidos para detectar mudanças no sistema remoto.
+5. **Observabilidade**: instrumentar `MetricsFacade` para registrar qual adapter foi usado, tempo de resposta, cache hit/miss e ID de correlação, expondo métricas Prometheus segmentadas por fonte de dados.【F:backend/core/application/services/metrics_facade.py†L41-L199】【F:backend/core/infrastructure/cache/unified_cache.py†L1-L118】
+
+## 6. Integração com os Planos de Ação Existentes
+- **Fase 0 – Hardening arquitetural**: executar itens 4.1.1–4.1.4 antes dos planos de serviços/hooks descritos em `action_plans`, garantindo base estável para codegen e OpenAPI.【F:docs/action_plans/README.md†L7-L23】
+- **Fase 1 – Contratos & Codegen**: alinhar `ApiResponse<T>` e publicar OpenAPI; em seguida, regenerar tipos no frontend para remover _fallbacks_ manuais.【F:frontend/services/api.ts†L11-L57】
+- **Fase 2 – Hooks e Observabilidade**: atualizar `useMetrics/useRanking/useTickets` para consumir filtros, expor status de cache e integrar métricas no dashboard conforme metas de SLA.
+- **Fase 3 – Extensão de endpoints**: somente após consolidação estrutural, implementar `/alerts`, `/technician-performance`, `/health` conforme planos específicos.
+
+## 7. Próximos Passos e Riscos
+1. **Mapear dependências críticas**: listar quais telas/relatórios dependem da cadeia legacy antes de desativá-la.
+2. **Criar _playbook_ de rollback**: documentar como reativar `USE_LEGACY_SERVICES` e mocks se a nova cadeia falhar em produção.【F:backend/config/settings.py†L78-L90】
+3. **Versionar _criteria_ GLPI**: armazenar consultas validadas (ex.: JSON/YAML) para comparação automática entre versões.
+4. **Riscos principais**:
+   - Quebra de filtros GLPI por alterações silenciosas no servidor – mitigado com testes de regressão baseados nas montagens atuais.【F:backend/services/legacy/metrics_service.py†L73-L158】
+   - Divergência entre contrato backend ↔ frontend – mitigado com codegen e lint de contratos.【F:frontend/types/api.ts†L1-L99】
+   - Falta de isolamento do cache em produção multi-worker – considerar backend Redis ou invalidar cache ao iniciar múltiplos processos.【F:backend/core/infrastructure/cache/unified_cache.py†L1-L118】
+
+Com estes ajustes e governança, o projeto ganha rastreabilidade, elimina inconsistências históricas e cria base sólida para evoluir o dashboard sem replicar dívidas técnicas.

--- a/refatorado/glpi_dashboard/01_Principios_Arquitetura.md
+++ b/refatorado/glpi_dashboard/01_Principios_Arquitetura.md
@@ -1,0 +1,49 @@
+# 01 — Princípios de Arquitetura
+
+## 1. Valores Fundamentais
+1. **Domínio primeiro**: entidades e regras de negócio do Service Desk (Ticket, Técnico, Fila, SLA, Categoria, Atendimento) vivem em módulos independentes de framework.
+2. **Isolamento de integrações**: qualquer comunicação com a API GLPI, cache, filas ou storage externo ocorre por meio de _adapters_ plugáveis.
+3. **Fluxo de dados mensurável**: cada métrica exposta no dashboard deve ter rastreabilidade ponta a ponta (GLPI → ingestão → agregação → API → UI).
+4. **Observabilidade como requisito**: logs estruturados, métricas técnicas e rastreamento distribuído são obrigatórios para detectar regressões cedo.
+5. **Contrato explícito**: não há acesso direto a modelos ou serviços de outra camada sem passar por interfaces públicas revisadas.
+
+## 2. Estilo Arquitetural
+- **Clean Architecture + Ports & Adapters**: domínio no centro, seguido de casos de uso, interfaces, infraestrutura e apresentação.
+- **Hexagonal Services**: cada módulo expõe portas de entrada (casos de uso) e portas de saída (repositórios/adapters) com dependência invertida.
+- **Event-driven para ingestão**: os workers traduzem eventos GLPI (ticket criado, atualizado, encerrado) para mensagens internas, permitindo reprocessamento idempotente.
+- **GraphQL federado / REST curado**: a API pública oferece endpoints normalizados, enquanto um gateway interno pode expor GraphQL para agregações complexas.
+
+## 3. Padrões de Projeto Obrigatórios
+| Camada                | Padrões aplicáveis                                                                 | Objetivo                                                                 |
+|-----------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| Domínio               | Value Objects, Aggregate Roots, Domain Services                                     | Garantir invariantes (SLA, estados do ticket) e reduzir repetição.       |
+| Aplicação (casos uso) | Command Handler, Query Handler, DTOs                                               | Orquestrar fluxos sem lidar com detalhes técnicos.                       |
+| Infraestrutura        | Adapter, Repository, Gateway, Strategy, Circuit Breaker, Retry with backoff        | Encapsular GLPI, caches, filas e fontes analíticas.                      |
+| Frontend              | Container/Presenter, Hooks especializados, Componentes Dumb/Smart, Atomic Design   | Separar lógica de dados de UI e garantir reuso consistente.              |
+
+## 4. Heurísticas de Decisão
+- **Adicionar dependência externa** somente se reduzir substancialmente o esforço total e existir plano de atualização/monitoramento.
+- **Preferir configuração declarativa** (YAML/TOML/JSON) a _hardcode_, facilitando testes e _feature flags_.
+- **Evitar acoplamento temporal**: processos assíncronos devem ter _timeouts_, retries e _dead-letter queues_.
+- **Pensar em _failure modes_**: para cada caso de uso, documentar comportamento em quedas do GLPI, lentidão de rede e dados inconsistentes.
+- **Priorizar simplicidade progressiva**: começar com o mínimo necessário, mas com espaço para escalar (ex.: usar Redis para cache, mas encapsulado para eventual troca).
+
+## 5. Gestão de Dependências
+1. **Camadas podem depender apenas de interfaces dos níveis internos**.
+2. **Bibliotecas comuns** vivem em `packages/` e expõem APIs versionadas (`semantic versioning` interno).
+3. **Feature Flags** controlam ativações graduais, evitando "big bang".
+4. **Não existe import relativo atravessando limites de contexto**: comunicação sempre via casos de uso ou eventos.
+
+## 6. Segurança e Compliance
+- Armazenamento seguro de _secrets_ em `Vault`/`AWS Secrets Manager` (ou equivalente), carregados via variáveis de ambiente.
+- Tokens GLPI renovados com _refresh schedulers_ monitorados.
+- Sanitização e _rate limiting_ na API pública.
+- Auditoria de acesso às métricas sensíveis (SLA, produtividade individual) com _trails_ imutáveis.
+
+## 7. Estratégia de Evolução
+- **Refatorar com propósito**: qualquer alteração estrutural requer RFC documentada aqui.
+- **Testes de mutação** para garantir robustez de regras críticas (cálculo de SLA, ranking).
+- **Playbooks de rollback**: cada deploy possui instruções de reversão e _feature toggles_ associados.
+- **Métricas de arquitetura**: acompanhar _cycle time_, _deploy frequency_, _mean time to restore_ e _change fail percentage_.
+
+> Estes princípios são vinculantes para toda a equipe. Divergências devem ser registradas em RFC antes de qualquer implementação.

--- a/refatorado/glpi_dashboard/02_Estrutura_Pastas.md
+++ b/refatorado/glpi_dashboard/02_Estrutura_Pastas.md
@@ -1,0 +1,95 @@
+# 02 — Estrutura de Pastas Planejada
+
+A estrutura proposta evita sobreposição de responsabilidades, elimina dependências cíclicas e isola código legado. O nível superior da aplicação refatorada ficará assim:
+
+```
+glpi_dashboard/
+├── apps/
+│   ├── api/                 # FastAPI (ou equivalente) expondo REST + GraphQL
+│   ├── worker_ingestion/    # Workers assíncronos responsáveis por consumir GLPI e publicar eventos internos
+│   └── frontend/            # Dashboard React/Next.js consumindo métricas normalizadas
+├── packages/
+│   ├── core_domain/         # Entidades, value objects, casos de uso e regras de negócio puras
+│   ├── glpi_contracts/      # Clientes, DTOs e mapeadores específicos da API GLPI (criteria inclusos)
+│   ├── data_pipeline/       # Agregadores, cálculos de métricas, serviços de cache e normalização
+│   └── shared/              # Utilidades (logger, config, autenticação, feature flags)
+├── platform/
+│   ├── infrastructure/      # Helm, Terraform, Docker, templates de observabilidade, secrets
+│   ├── ci_cd/               # Pipelines, workflows, templates de qualidade
+│   └── docs/                # Runbooks operacionais e SLOs
+├── docs/                    # Documentação técnica gerada automaticamente (OpenAPI, ADRs, relatórios)
+└── tests/
+    ├── unit/
+    ├── integration/
+    └── contract/
+```
+
+## 1. `apps/`
+- **api**
+  - `/src/main.py`: ponto de entrada da aplicação.
+  - `/src/interfaces/rest/`: controladores REST agrupados por contexto (tickets, técnicos, SLA).
+  - `/src/interfaces/graphql/`: _resolvers_ para consultas agregadas.
+  - `/src/config/`: carregamento tipado de environment.
+  - Depende apenas de pacotes internos (`core_domain`, `data_pipeline`, `shared`).
+
+- **worker_ingestion**
+  - `/src/consumers/glpi_polling.py`: fallback de polling usando `criteria` pré-configurados.
+  - `/src/consumers/webhook.py`: entrada para _webhooks_ caso o GLPI suporte.
+  - `/src/publishers/event_bus.py`: envia mensagens para Kafka/Rabbit/Redis Streams.
+  - `/src/schedulers/`: _cron jobs_ para sincronizações completas e _refresh_ de tokens.
+
+- **frontend**
+  - `/app/` (Next.js) ou `/src/` (React Vite) com Atomic Design.
+  - `/app/services/metricsClient.ts`: gateway único para a API.
+  - `/app/state/`: store (Zustand/Redux) com _slices_ por domínio.
+  - `/app/components/`: `atoms`, `molecules`, `organisms`, `layouts`.
+
+## 2. `packages/`
+- **core_domain**
+  - `/tickets/`: entidades, agregados (TicketAggregate), políticas de SLA.
+  - `/technicians/`: ranking, produtividade, disponibilidade.
+  - `/alerts/`: regras de notificação e thresholds.
+  - `/common/`: tipos compartilhados (ServiceDeskID, TimeWindow, SLAStatus).
+
+- **glpi_contracts**
+  - `/client/`: wrappers HTTP com _retry_, _circuit breaker_, paginação e geração de `criteria`.
+  - `/schemas/`: objetos de transporte validados (Pydantic) espelhando respostas GLPI.
+  - `/mappers/`: transforma payloads GLPI → domínio.
+  - `/fixtures/`: exemplos versionados para testes de contrato.
+
+- **data_pipeline**
+  - `/aggregators/`: cálculos de backlog, SLA, funil.
+  - `/repositories/`: abstração sobre bancos analíticos (Postgres, ClickHouse) e caches.
+  - `/services/`: composição de agregadores em casos de uso.
+
+- **shared**
+  - `/config/`: carregamento de `.env`, _feature flags_, _secrets_.
+  - `/logging/`: padrão estruturado com _trace id_.
+  - `/monitoring/`: exporters de métricas Prometheus, tracing OpenTelemetry.
+
+## 3. `platform/`
+Centraliza tópicos que hoje estão dispersos ou ausentes:
+- **infrastructure**: manifests de deploy, módulos Terraform, scripts de bootstrap.
+- **ci_cd**: pipelines com lint, testes, _contract tests_, _security scans_ e promoção controlada.
+- **docs**: manuais operacionais, playbooks de incidentes, SLO/SLA.
+
+## 4. `docs/`
+Documentação gerada automaticamente e artefatos que acompanham o código (ex.: OpenAPI, diagramas). O diretório atual `docs/` será migrado gradualmente para cá, respeitando uma taxonomia única.
+
+## 5. `tests/`
+Estrutura padronizada:
+- `unit/` alinhado com módulos de `packages/`.
+- `integration/` focado em orquestrações (API ↔ cache ↔ GLPI mock).
+- `contract/` validando compatibilidade com GLPI (`criteria`, esquemas) e frontend (Pact ou MSW). Nenhum teste unitário toca rede externa.
+
+## 6. Isolamento do Código Legado
+- **`legacy/` removido**: qualquer necessidade de referência ficará em um repositório arquivado ou em anexos de documentação.
+- **Migração assistida**: componentes que forem reaproveitados precisam passar por reescrita para se adequarem aos padrões anteriores. Copiar e colar é proibido.
+
+## 7. Convenções Transversais
+- Nomenclatura consistente (`snake_case` para Python, `camelCase`/`PascalCase` para TypeScript/React).
+- Imports absolutos baseados em módulos (`from packages.core_domain.tickets import ...`).
+- _Lint_ padronizado (`ruff`, `mypy`, `eslint`, `stylelint`).
+- Arquivos `__init__.py` apenas quando necessário, com exportações explícitas.
+
+> Qualquer novo diretório deve ser registrado aqui antes de existir no código-fonte.

--- a/refatorado/glpi_dashboard/03_Contratos_Backend.md
+++ b/refatorado/glpi_dashboard/03_Contratos_Backend.md
@@ -1,0 +1,100 @@
+# 03 — Contratos do Backend
+
+## 1. Visão Geral
+O backend refatorado será composto por três subsistemas cooperantes:
+
+1. **Ingestão** (`apps/worker_ingestion` + `packages/glpi_contracts`)
+   - Responsável por consumir a API GLPI usando `criteria` determinísticos.
+   - Publica eventos normalizados (`TicketCreated`, `TicketUpdated`, `TechnicianAssignmentChanged`, `SLAClockTicked`).
+
+2. **Core de Métricas** (`packages/core_domain` + `packages/data_pipeline`)
+   - Processa eventos, mantém projeções (Postgres/ClickHouse) e expõe casos de uso (`GetTicketsBacklog`, `GetTechnicianRanking`, `GetSlaBreaches`).
+
+3. **API Pública** (`apps/api`)
+   - Disponibiliza REST e GraphQL, aplica autenticação/autorizações, caching e rate limiting.
+
+```
+GLPI API ──> Ingestão (workers) ──> Event Bus ──> Processadores de Métricas ──> Storage Analítico ──> API ──> Frontend/Integradores
+```
+
+## 2. Contextos de Domínio e Casos de Uso
+| Contexto          | Casos de uso principais                                | Entradas                                                   | Saídas/Contratos                                                                 |
+|-------------------|---------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------|
+| Tickets           | `GetTicketsOverview`, `GetTicketTimeline`, `SyncTicket` | `ServiceDeskID`, `TimeWindow`, filtros (`status`, `queue`) | DTO `TicketSummary`, coleção `TicketTimelineEvent`, projeção `TicketAging`      |
+| Técnicos          | `GetTechnicianRanking`, `GetTechnicianProductivity`     | `TeamID`, `Period`, métricas alvo (`handled`, `sla`)        | DTO `TechnicianScorecard`, `RankingEntry`, breakdown por faixa horária          |
+| SLA/Alertas       | `GetSlaBreaches`, `GetAlertRules`, `AckAlert`           | `TimeWindow`, `Severity`, `Channel`                        | DTO `SlaBreach`, `AlertRule`, `AckReceipt`                                      |
+| Saúde do Sistema  | `GetIngestionLag`, `GetApiUsage`, `GetDataFreshness`    | `None`                                                     | DTO `LagReport`, `UsageStats`, `FreshnessIndicator`                             |
+
+Cada caso de uso segue o contrato:
+- **Input DTO** validado (Pydantic) → `UseCase.execute(input: InputDTO) -> OutputDTO`.
+- **Output DTO** serializado apenas pela camada de apresentação (REST/GraphQL), nunca pelos casos de uso.
+
+## 3. Integração com o GLPI
+### 3.1 Cliente HTTP
+- Baseado em `httpx.AsyncClient` com `retry` exponencial e `circuit breaker`.
+- Suporta `async with GLPIClient() as client` garantindo _session pooling_.
+- Recebe `criteria` já construídos e injeta filtros padronizados (`is_deleted = 0`, `with_tsl = true`, etc.).
+
+### 3.2 Geração de `criteria`
+- Builder declarativo localizado em `packages/glpi_contracts/client/criteria_builder.py`.
+- Entrada: `CriteriaSpec` (lista de `Filter`, `Sort`, `Limit`).
+- Saída: string JSON conforme padrão GLPI, com validação automática contra _fixtures_.
+- Biblioteca garante:
+  - Escapagem correta de nomes de campos.
+  - Combinação de filtros (`AND`/`OR`) por meio de objetos imutáveis.
+  - Templates reutilizáveis para `tickets`, `users`, `groups`, `locations`.
+
+### 3.3 Normalização
+- Mapeadores convertem respostas GLPI em Value Objects internos.
+- Campos opcionais ou inconsistentes são tratados com `Maybe/Option`, evitando `None` propagado.
+- Divergências são logadas e enviadas para a fila de _dead letter_ para inspeção manual.
+
+### 3.4 Contratos de Eventos
+Todos os eventos publicados pelo worker seguem schema Avro/JSON Schema versionado:
+- `TicketCreatedV1`
+- `TicketUpdatedV1`
+- `TechnicianAssignmentChangedV1`
+- `TicketSlaBreachedV1`
+
+Compatibilidade retroativa garantida com versionamento `V{major}` na chave `type`.
+
+## 4. API Pública
+### 4.1 REST
+| Método | Endpoint                         | Caso de uso                       | Autenticação | Cache TTL | Observações                                   |
+|--------|----------------------------------|------------------------------------|--------------|-----------|------------------------------------------------|
+| GET    | `/v1/tickets/overview`           | `GetTicketsOverview`               | Bearer (JWT) | 60 s      | Filtros: `queue`, `priority`, `category`       |
+| GET    | `/v1/tickets/{id}/timeline`      | `GetTicketTimeline`                | Bearer       | 0 s       | Retorna eventos ordenados + SLAs              |
+| GET    | `/v1/technicians/ranking`        | `GetTechnicianRanking`             | Bearer       | 300 s     | Suporte a paginação e agrupamento por equipe  |
+| GET    | `/v1/sla/breaches`               | `GetSlaBreaches`                   | Bearer       | 60 s      | Permite `severity`, `timeWindow`              |
+| GET    | `/v1/system/health`              | `GetIngestionLag` + `GetDataFreshness` | Bearer   | 30 s      | Usado para _status page_                     |
+
+### 4.2 GraphQL
+- _Schema_ hospedado em `/graphql` com _introspection_ desabilitada em produção.
+- _Queries_ principais: `ticketsBacklog`, `technicianLeaderboard`, `slaTrends(period: TimeRange)`.
+- _Subscriptions_ opcionais para alertas em tempo real (ex.: via WebSocket + Redis Pub/Sub).
+
+### 4.3 Autorização e Rate Limiting
+- JWT com _scopes_: `dash.read`, `dash.admin`, `dash.observability`.
+- Limite de 100 req/min por chave + _burst_ de 20 req.
+- Possibilidade de emitir _API Keys_ para integrações externas com _quotas_ diferenciadas.
+
+## 5. Persistência e Cache
+- **Banco transacional (GLPI)**: apenas leitura via API.
+- **Banco analítico**: Postgres inicialmente, com plano de migração para ClickHouse quando volume crescer.
+- **Cache**: Redis com _namespaces_ (`metrics:tickets`, `metrics:technicians`). TTLs definidos por endpoint.
+- **Storage de arquivos**: S3/GCS para exportações ou anexos.
+- **Migrations**: `alembic` aplicado somente no banco analítico.
+
+## 6. Observabilidade e Resiliência
+- _Tracing_ completo (`trace_id` propagado desde o worker até a API).
+- Métricas técnicas: `ingestion.lag`, `api.latency`, `api.error_rate`, `glpi.retries`, `glpi.criteria_failures`.
+- Alertas automáticos quando `lag > 5 min` ou `criteria_failures > 0` em 5 minutos.
+- _Chaos testing_: cenários simulados de queda do GLPI, _throttling_ e respostas inconsistentes.
+
+## 7. Contratos de Qualidade
+1. **Testes de contrato GLPI** executados a cada mudança no `criteria_builder`.
+2. **Snapshot tests** para DTOs expostos pelos casos de uso.
+3. **Contract tests** REST/GraphQL usando Pact para garantir compatibilidade com o frontend.
+4. **Coverage mínima**: 90% em `core_domain`, 80% em `data_pipeline`, 70% no restante.
+
+> Qualquer alteração nos contratos acima exige atualização desta documentação e revisão com o time de arquitetura.

--- a/refatorado/glpi_dashboard/04_Contratos_Frontend.md
+++ b/refatorado/glpi_dashboard/04_Contratos_Frontend.md
@@ -1,0 +1,84 @@
+# 04 — Contratos do Frontend
+
+## 1. Visão Geral
+O novo dashboard será implementado em **React 18 + TypeScript**, com Next.js (app router) para renderização híbrida e caching avançado. Os componentes consomem apenas os contratos definidos pelo backend (`/v1` REST e `/graphql`). Não há chamadas diretas à API do GLPI.
+
+```
+Next.js (app router)
+├── Layouts (dashboard, fullscreen, embeddable)
+├── Feature modules (tickets, technicians, sla, observability)
+├── Shared UI (design system)
+└── Infrastructure (state, services, analytics)
+```
+
+## 2. Navegação e Fluxos Principais
+- **Dashboard Geral** (`/dashboard`): KPIs de backlog, tickets novos, SLA e alertas.
+- **Detalhe de Tickets** (`/tickets`): tabela com filtros avançados + modal de timeline.
+- **Ranking de Técnicos** (`/technicians`): leaderboard, detalhes de produtividade por período.
+- **Saúde do Sistema** (`/observability`): monitoramento do _lag_ de ingestão, status de jobs e uso da API.
+- **Administração** (`/admin/alerts`): gestão de alertas e thresholds (feature flag inicial).
+
+Cada rota é definida via `app/(dashboard)/[feature]/page.tsx` com carregamento por segmento.
+
+## 3. Serviços de Dados
+- Camada única `app/services/metricsClient.ts` exporta funções:
+  - `fetchTicketsOverview(filters: TicketsFilters): Promise<TicketsOverviewDTO>`
+  - `fetchTicketTimeline(id: TicketId): Promise<TicketTimelineDTO>`
+  - `fetchTechnicianRanking(params: RankingParams): Promise<TechnicianRankingDTO>`
+  - `fetchSlaBreaches(window: TimeWindow): Promise<SlaBreachesDTO>`
+  - `fetchSystemHealth(): Promise<SystemHealthDTO>`
+- Implementação usa `@tanstack/react-query` (server + client components) com caching e revalidação automática.
+- Tratamento de erros centralizado (mapeia códigos HTTP para estados de UI).
+- Requisições autenticadas via `fetch` com `Authorization: Bearer` obtido do `authClient` (Next Auth ou Auth0), nunca armazenado em `localStorage`.
+
+## 4. Estado e Sincronização
+- **React Query** para estados remotos.
+- **Zustand** (`app/state/filtersStore.ts`) para estados compartilhados (filtros globais, preferências do usuário).
+- **Immer** para mutações imutáveis.
+- Persistência de preferências via `IndexedDB` com `idb-keyval`, versão controlada.
+
+## 5. Design System
+- Implementar `@glpi/design-system` (pasta `app/design-system/`):
+  - `tokens/` (cores, tipografia, espaçamento) em formato CSS variables + TypeScript.
+  - `components/` com camadas Atomic Design:
+    - `atoms/`: `KpiCard`, `StatusBadge`, `TimeRangePicker`.
+    - `molecules/`: `TicketsTable`, `TechnicianChartLegend`.
+    - `organisms/`: `TicketsOverviewPanel`, `TechnicianRankingBoard`, `SlaTrendChart`.
+  - Documentação via Storybook (rodando isolado em `apps/frontend`).
+- Gráficos construídos com `@tanstack/charts` ou `echarts-for-react` encapsulados em componentes reutilizáveis (`LineChart`, `StackedBarChart`).
+
+## 6. Contratos de UI ↔ Dados
+| Componente                 | DTO esperado                              | Requisição                       | Revalidação | Estados de erro                               |
+|----------------------------|-------------------------------------------|----------------------------------|-------------|-----------------------------------------------|
+| `TicketsOverviewPanel`     | `TicketsOverviewDTO`                      | `fetchTicketsOverview`           | 30 s        | `empty`, `glpiLag`, `partialData`, `unauthorized` |
+| `TicketTimelineModal`      | `TicketTimelineDTO`                       | `fetchTicketTimeline`            | on-demand   | `notFound`, `stale`, `unauthorized`            |
+| `TechnicianRankingBoard`   | `TechnicianRankingDTO`                    | `fetchTechnicianRanking`         | 5 min       | `empty`, `degraded`                            |
+| `SlaTrendChart`            | `SlaBreachesDTO`                          | `fetchSlaBreaches`               | 1 min       | `noData`, `glpiLag`                            |
+| `SystemHealthPanel`        | `SystemHealthDTO`                         | `fetchSystemHealth`              | 30 s        | `critical`, `warning`, `unknown`               |
+
+Todos os DTOs são importados do pacote `@glpi-dashboard/contracts` (gerado automaticamente a partir do backend).
+
+## 7. Experiência do Usuário e Acessibilidade
+- Layout responsivo (mobile-first) com breakpoints: `sm (640px)`, `md (768px)`, `lg (1024px)`, `xl (1280px)`.
+- Navegação por teclado e leitores de tela garantidos (`aria-*`, `role` adequados).
+- Dark mode padrão, com `prefers-color-scheme` e _toggle_ manual.
+- Feedback imediato em loading (`Skeletons`, `Shimmer`) e erros (`InlineAlert`).
+
+## 8. Observabilidade Cliente
+- Telemetria via `PostHog` ou `Amplitude` com coleta anônima.
+- _Logs_ de erros enviados para Sentry, incluindo `trace_id` recebido do backend.
+- Métricas de uso capturadas (`filtros aplicados`, `tempo em página`, `latência percepcionada`).
+
+## 9. Testes e Qualidade
+- **Storybook** com `Chromatic` para _visual regression_.
+- **Vitest + Testing Library** para testes de unidade/componentes.
+- **Playwright** para testes E2E, cobrindo fluxos críticos (dash geral, filtros, ranking, health).
+- **Contract tests**: frontend consome _mock server_ gerado a partir do OpenAPI/GraphQL do backend.
+- Regras de lint (`eslint`, `typescript-eslint`, `stylelint`) aplicadas em CI.
+
+## 10. Feature Flags e Deploy
+- Configuradas via `@glpi-dashboard/flags` (SDK interno) com providers (LaunchDarkly, Unleash ou arquivo JSON).
+- Deploy automático em Vercel (ou container em Kubernetes) com _preview_ para cada PR.
+- Política de _progressive rollout_: 5% → 25% → 100% com monitoramento da telemetria.
+
+> Alterações de layout ou contrato de dados exigem atualização coordenada com o backend e revisão desta especificação.

--- a/refatorado/glpi_dashboard/05_Governanca_Qualidade.md
+++ b/refatorado/glpi_dashboard/05_Governanca_Qualidade.md
@@ -1,0 +1,69 @@
+# 05 — Governança de Qualidade e Automação
+
+## 1. Objetivos
+Estabelecer mecanismos para impedir regressões estruturais, garantir consistência entre camadas e detectar violações arquiteturais antes que cheguem a produção.
+
+## 2. Fluxo de Desenvolvimento
+1. **RFC obrigatória** para mudanças que alterem estrutura, contratos ou integrações.
+2. **Branches curtas** (`feature/...`, `fix/...`) criadas a partir de `main`.
+3. **Pull Request** precisa referenciar seções desta documentação.
+4. **Code Review** em duas etapas:
+   - Review técnico (engenharia) → valida padrões de código e testes.
+   - Review de arquitetura (Arquiteto/Tech Lead) → confirma alinhamento com princípios.
+5. **Checklists automáticos** impedem merge sem todos os _checks_ verdes.
+
+## 3. Pipeline CI/CD
+| Etapa                | Ferramentas                         | Objetivo                                                                        |
+|----------------------|-------------------------------------|----------------------------------------------------------------------------------|
+| `lint`               | `ruff`, `mypy`, `black --check`, `eslint`, `stylelint` | Garantir padrões de estilo e tipagem.                                          |
+| `unit-tests`         | `pytest`, `vitest`                  | Validar lógica de domínio e componentes isolados.                              |
+| `contract-tests`     | `pytest` + `respx`, `pact`, `msw`   | Garantir compatibilidade GLPI ↔ backend ↔ frontend.                             |
+| `security`           | `bandit`, `pip-audit`, `npm audit`, `trivy` | Detectar vulnerabilidades.                                                     |
+| `build`              | Docker multi-stage, `next build`    | Confirmar que artefatos são geráveis.                                          |
+| `deploy-preview`     | Vercel / Kubernetes namespace       | Criar ambiente efêmero para QA e stakeholders.                                 |
+| `smoke-tests`        | `pytest -m smoke`, `playwright`     | Verificar endpoints críticos e páginas chave.                                  |
+
+## 4. Gatekeepers Arquiteturais
+- **Import Linter** configurado para bloquear dependências cíclicas entre pacotes.
+- **Deptry** evita dependências órfãs ou não utilizadas.
+- **Madge** (frontend) identifica ciclos de importação.
+- **ArchUnit (Python)** com regras customizadas assegurando limites de camadas (`apps` não importam diretamente `glpi_contracts`).
+- **Template de `pyproject.toml`** define extras opcionais (`api`, `worker`, `dev`) para evitar instalações desnecessárias.
+
+## 5. Dados e Integridade
+- **Testes de mutação** com `mutmut` (backend) e `stryker` (frontend) em _schedules_ semanais.
+- **Data quality checks**: dbt ou scripts `great_expectations` rodando após ingestões completas.
+- **Backfill seguro**: processos `one-shot` precisam de `dry-run` obrigatório e _toggle_ de enable/disable.
+- **Schema Registry**: eventos versionados via Confluent Schema Registry ou equivalente.
+
+## 6. Observabilidade e Alertas
+- **Prometheus/Grafana**: métricas técnicas e de negócio.
+- **Loki/ELK**: logs estruturados com `trace_id`.
+- **Tempo real**: dashboards de ingestão (lag, throughput, retries) e API (p95 latency, error rate).
+- **Alertas**: PagerDuty/Telegram integrados com thresholds definidos em `platform/docs/slo.md`.
+
+## 7. Gestão de Configuração
+- Variáveis sensíveis somente em `platform/infrastructure/secrets/` (criptografado).
+- Configurações por ambiente em `config/*.yaml` carregadas via `shared.config`.
+- _Feature flags_ armazenadas em provider dedicado, nunca em código.
+- _Secrets_ rotacionados trimestralmente e auditados automaticamente.
+
+## 8. Documentação Viva
+- Este diretório (`refatorado/glpi_dashboard`) é espelhado no Confluence/Notion, com sincronização automática a cada merge.
+- **ADR (Architecture Decision Records)** em `docs/adrs/` complementam mudanças.
+- _Changelog_ automatizado com `git-cliff`.
+- _Diagrams as Code_ (Structurizr, Mermaid) versionados em `docs/`.
+
+## 9. Políticas de Deploy
+- `main` sempre _deployable_.
+- Deploy contínuo automatizado após aprovação manual (gate de produto).
+- _Canary releases_ monitoradas por 30 minutos antes de _rollout_ completo.
+- _Rollback_ automático se `error_rate > 3%` ou `lag > 10 min` pós-deploy.
+
+## 10. Governança de Pessoas e Processos
+- Reuniões semanais de arquitetura para revisar métricas e dívidas.
+- _Pairing_ obrigatório para mudanças em módulos críticos (`criteria_builder`, `aggregators`, `ranking`).
+- _Post-mortem_ padrão (`blameless`) para incidentes > 1h, com ações registradas em backlog.
+- Capacitação contínua (trilhas internas) para GLPI API, Clean Architecture, Observabilidade.
+
+> O não cumprimento destes guardrails bloqueia releases e deve ser tratado como incidente crítico.

--- a/refatorado/glpi_dashboard/06_Roadmap_Implementacao.md
+++ b/refatorado/glpi_dashboard/06_Roadmap_Implementacao.md
@@ -1,0 +1,79 @@
+# 06 — Roadmap de Implementação
+
+## Visão Geral
+O roadmap prioriza estabilidade e previsibilidade. Cada fase só inicia após os critérios de saída da fase anterior serem atendidos e registrados em checklist compartilhado.
+
+## Fase 0 — Alinhamento & Preparação
+- [ ] Aprovar documentos `01` a `05` com stakeholders.
+- [ ] Criar RFC de migração formalizando escopo, riscos e plano de comunicação.
+- [ ] Provisionar repositório limpo (`glpi_dashboard_refactor`) com CI/CD base configurada.
+- [ ] Definir papéis de cada squad/tribo no plano (ingestão, backend, frontend, DevOps).
+
+## Fase 1 — Fundações Técnicas
+- [ ] Implementar skeleton da estrutura de pastas proposta (sem lógica de negócio).
+- [ ] Configurar toolchain: `poetry`/`uv`, `npm`/`pnpm`, `pre-commit` com hooks obrigatórios.
+- [ ] Configurar pipeline CI com estágios `lint`, `tests` (placeholders), `build`.
+- [ ] Estabelecer observabilidade básica (logging estruturado, tracing stub, métricas dummy).
+- [ ] Criar ADRs iniciais para escolhas de stack (Next.js, FastAPI, Redis, etc.).
+
+**Critérios de saída:** projeto gera build vazio, pipelines passam, documentação atualizada.
+
+## Fase 2 — Ingestão GLPI
+- [ ] Construir `packages/glpi_contracts` com cliente HTTP, autenticação e builder de `criteria`.
+- [ ] Implementar workers de polling com rotinas de paginação e retries.
+- [ ] Definir schemas de eventos (`TicketCreatedV1`, etc.) e registrar no schema registry.
+- [ ] Criar _mocks_ do GLPI para testes (`respx`, _fixtures_ reais anonimizados).
+- [ ] Medir latência/lag esperado e documentar limites.
+
+**Critérios de saída:** eventos publicados em ambiente de teste, contratos de criteria cobertos por testes automatizados.
+
+## Fase 3 — Núcleo de Métricas
+- [ ] Modelar entidades/domínios em `core_domain` (tickets, técnicos, SLA, alertas).
+- [ ] Implementar agregadores em `data_pipeline` com armazenamentos temporários (Postgres in-memory).
+- [ ] Escrever casos de uso `GetTicketsOverview`, `GetTechnicianRanking`, `GetSlaBreaches`, `GetSystemHealth`.
+- [ ] Construir testes unitários e de integração garantindo consistência com eventos de ingestão.
+- [ ] Instrumentar métricas técnicas (`ingestion.lag`, `aggregation.duration`).
+
+**Critérios de saída:** casos de uso retornam dados coerentes a partir de eventos simulados, cobertura mínima atingida.
+
+## Fase 4 — API Pública
+- [ ] Levantar endpoints REST definidos em `03_Contratos_Backend.md` com FastAPI.
+- [ ] Configurar GraphQL gateway (Strawberry ou Ariadne) com esquemas e resolvers.
+- [ ] Implementar autenticação JWT + escopos, rate limiting e caching.
+- [ ] Gerar documentação OpenAPI/GraphQL automatizada.
+- [ ] Criar testes de contrato (Pact) e smoke tests.
+
+**Critérios de saída:** API em ambiente de staging com documentação disponível e testes de contrato verdes.
+
+## Fase 5 — Frontend
+- [ ] Criar estrutura Next.js com módulos e design system conforme `04_Contratos_Frontend.md`.
+- [ ] Implementar componentes-chave: `TicketsOverviewPanel`, `TechnicianRankingBoard`, `SlaTrendChart`, `SystemHealthPanel`.
+- [ ] Integrar React Query + Zustand com serviços de dados.
+- [ ] Configurar Storybook, Chromatic e testes (Vitest, Playwright).
+- [ ] Implementar telemetria (PostHog/Sentry) com `trace_id`.
+
+**Critérios de saída:** dashboard funcional em staging, Storybook publicado, testes E2E cobrindo fluxos principais.
+
+## Fase 6 — Observabilidade & Confiabilidade
+- [ ] Completar painéis Grafana (ingestão, API, frontend).
+- [ ] Configurar alertas no PagerDuty/Telegram baseados em SLOs.
+- [ ] Realizar _chaos day_ simulando indisponibilidade do GLPI.
+- [ ] Documentar runbooks de incidentes e procedimentos de rollback.
+
+**Critérios de saída:** alertas disparam corretamente em testes, runbooks revisados pelo time.
+
+## Fase 7 — Migração & Go-Live
+- [ ] Executar backfill histórico controlado.
+- [ ] Conduzir testes paralelos (legacy vs refatorado) comparando métricas chave.
+- [ ] Treinar usuários finais e atualizar documentação externa.
+- [ ] Realizar _canary release_ (5% → 25% → 100%).
+- [ ] Arquivar repositório legado e congelar deploys antigos.
+
+**Critérios de saída:** métricas de negócio equivalentes ou melhores que o legado, incidentes zero durante rollout.
+
+## Fase 8 — Pós-Go-Live & Melhoria Contínua
+- [ ] Revisão de lições aprendidas e ajustes nos documentos.
+- [ ] Planejar incrementos (novos KPIs, automações) com base em feedback.
+- [ ] Estabelecer ciclo trimestral de auditoria arquitetural usando estes documentos como baseline.
+
+> Qualquer alteração na ordem ou conteúdo deste roadmap deve ser validada em reunião de arquitetura e registrada em ADR.

--- a/refatorado/glpi_dashboard/07_Validacao_Completude.md
+++ b/refatorado/glpi_dashboard/07_Validacao_Completude.md
@@ -1,0 +1,34 @@
+# 07 — Validação de Completude da Documentação
+
+## 1. Objetivo da Validação
+Confirmar que o conjunto documental `01` a `06` cobre integralmente os requisitos arquiteturais, operacionais e de entrega para reconstruir o GLPI Dashboard sem reincidir nas dívidas técnicas identificadas na auditoria.
+
+## 2. Critérios Utilizados
+- **Cobertura arquitetural**: existência de princípios e padrões vinculantes para backend, frontend e pipelines de dados.
+- **Contratos explícitos**: definição inequívoca das interfaces entre GLPI ⇄ ingestão ⇄ núcleo de métricas ⇄ API ⇄ frontend.
+- **Governança preventiva**: guardrails automatizados, fluxos de revisão e métricas operacionais que impeçam reincidência de inconsistências.
+- **Roadmap executável**: sequência faseada com critérios de saída mensuráveis para cada etapa.
+- **Aderência ao estado atual**: preservação do conhecimento crítico (`criteria` GLPI) mapeado na auditoria.
+
+## 3. Resultado por Documento
+| Documento | Escopo Validado | Observações |
+|-----------|-----------------|-------------|
+| [01_Principios_Arquitetura](01_Principios_Arquitetura.md) | Valores, estilo arquitetural e padrões obrigatórios para todas as camadas. | Regras de dependência, segurança e evolução cobrem casos de refatoração gradual e _feature flags_. |
+| [02_Estrutura_Pastas](02_Estrutura_Pastas.md) | Layout canônico de diretórios para apps, pacotes compartilhados, plataforma e testes. | Elimina sobreposição `legacy`, impõe convenções de nomenclatura e registro prévio de novos módulos. |
+| [03_Contratos_Backend](03_Contratos_Backend.md) | Casos de uso, integrações GLPI, especificação REST/GraphQL, eventos e observabilidade. | Inclui `criteria_builder`, schemas versionados e requisitos de testes de contrato para garantir paridade com GLPI. |
+| [04_Contratos_Frontend](04_Contratos_Frontend.md) | Navegação, serviços de dados, estado, design system, UX e testes E2E. | Obriga consumo exclusivo dos contratos do backend, telemetria cliente e acessibilidade. |
+| [05_Governanca_Qualidade](05_Governanca_Qualidade.md) | Pipeline CI/CD, gatekeepers arquiteturais, políticas de deploy e documentação viva. | Instrumenta lint, testes, segurança, mutação e observabilidade para bloquear regressões estruturais. |
+| [06_Roadmap_Implementacao](06_Roadmap_Implementacao.md) | Sequência faseada (Fase 0 → 8) com critérios de saída objetivos. | Garante preparação (CI, observabilidade), ingestão GLPI, núcleo de métricas, API, frontend e operações. |
+
+## 4. Cobertura de Riscos Críticos
+- **`criteria` GLPI**: preservados por meio do pacote `glpi_contracts`, testes de contrato e versionamento de fixtures (Docs 03 e 06).
+- **Divergência de contratos backend/frontend**: mitigada com geração automática de tipos, Pact/MSW e governança (Docs 03, 04 e 05).
+- **Observabilidade ponta a ponta**: exigida em princípios, contratos e governança; métricas específicas (`ingestion.lag`, `api.latency`, `trace_id` propagado) tornam falhas auditáveis.
+- **Controle de qualidade**: pipeline CI/CD com lint, testes, auditoria de dependências, mutação e smoke tests impede merges com inconsistências.
+- **Roadmap seguro**: critérios de saída explicitam _definition of done_ por fase, evitando saltos sem infraestrutura pronta.
+
+## 5. Lacunas e Mitigações
+Nenhuma lacuna estrutural foi identificada durante a validação. Ajustes ou escolhas de implementação (ex.: seleção definitiva de banco analítico, provider de feature flags) já estão condicionados a RFCs e ADRs antes da execução, garantindo rastreabilidade.
+
+## 6. Conclusão
+O pacote documental `01` a `06`, complementado pela auditoria existente, fornece instruções suficientes para que uma equipe implemente um backend/worker/frontend capazes de consumir o GLPI via `criteria`, consolidar métricas e apresentá-las no dashboard com governança robusta. Seguindo o roadmap estabelecido, o projeto resultante terá arquitetura limpa, contratos consistentes e mecanismos de prevenção de dívida técnica, ficando pronto para operar em produção e exibir os dados do GLPI com confiabilidade.

--- a/refatorado/glpi_dashboard/08_Prompt_Guia_Execucao.md
+++ b/refatorado/glpi_dashboard/08_Prompt_Guia_Execucao.md
@@ -1,0 +1,37 @@
+# 08 — Prompt Orquestrador para Execução da Refatoração
+
+Use este prompt com agentes especializados (ou uma única IA generalista) sempre que uma nova etapa da refatoração for iniciada. Ele garante aderência aos documentos `01` a `07`, ao roadmap e às políticas de governança.
+
+---
+**Identidade**
+Você é o **GLPIRefactorOrchestrator**, um agente líder responsável por coordenar subagentes (GLPIDataIngestor, MetricsCoreEngineer, APIArchitect, DashboardDesigner, DevOpsGuard). Sua missão é reconstruir o GLPI Dashboard seguindo estritamente as diretrizes documentadas em `refatorado/glpi_dashboard/` e manter rastreabilidade das decisões.
+
+**Instruções**
+1. Nenhuma implementação pode iniciar sem validar os critérios da fase corrente em `06_Roadmap_Implementacao.md`.
+2. Toda decisão deve citar explicitamente as seções relevantes dos documentos `01` a `07`.
+3. Ao detectar lacunas ou ambiguidades, produza uma RFC referenciando `07_Validacao_Completude.md` antes de propor código.
+4. Garanta que contratos entre camadas sigam `03_Contratos_Backend.md` e `04_Contratos_Frontend.md` sem alterações silenciosas.
+5. Aplique os guardrails de `05_Governanca_Qualidade.md` (lint, testes, observabilidade) como parte integrante do plano de ação.
+6. Preserve o conhecimento sobre `criteria` da API GLPI conforme descrito em `03_Contratos_Backend.md` e na auditoria `docs/AUDITORIA_ARQUITETURA_CONSISTENCIA.md`.
+7. Documente no final de cada ciclo: decisões, entregáveis, riscos emergentes e próximos passos.
+
+**Contexto Obrigatório**
+- Estado atual do código (auditoria em `docs/AUDITORIA_ARQUITETURA_CONSISTENCIA.md`).
+- Diretrizes estratégicas: `01_Principios_Arquitetura.md`, `02_Estrutura_Pastas.md`.
+- Contratos e integrações: `03_Contratos_Backend.md`, `04_Contratos_Frontend.md`.
+- Governança: `05_Governanca_Qualidade.md`.
+- Roadmap e critérios de saída: `06_Roadmap_Implementacao.md`.
+- Validação de completude e controle de riscos: `07_Validacao_Completude.md`.
+
+**Pergunta + Cadeia de Raciocínio**
+"Com base nos documentos citados, qual é o plano detalhado para concluir a próxima fase do roadmap, garantindo que:
+- todas as premissas arquiteturais sejam satisfeitas;
+- os contratos entre subsistemas permaneçam coerentes;
+- existam verificações automatizadas de qualidade e observabilidade;
+- o manuseio de `criteria` GLPI esteja correto e testado;
+- os critérios de saída definidos sejam atendidos com evidências mensuráveis?
+
+Liste as subtarefas, agentes responsáveis, dependências, riscos mitigados e artefatos a produzir. Antes de executar cada subtarefa, reavalie se novas informações alteram as premissas. Explique seu raciocínio passo a passo e só então apresente o plano final."
+---
+
+> Reutilize este prompt em todas as cerimônias de planejamento (início de fase, refinamento de épicos, revisões). Ajustes posteriores devem ser versionados aqui.

--- a/refatorado/glpi_dashboard/README.md
+++ b/refatorado/glpi_dashboard/README.md
@@ -1,0 +1,34 @@
+# Plano de Refatoração do GLPI Dashboard
+
+## Contexto
+O estado atual do projeto acumula serviços duplicados, pastas desatualizadas e integrações fragilizadas com a API do GLPI. As tentativas recentes de reutilizar scripts da pasta `service/legacy/` evidenciaram inconsistências e baixa previsibilidade: apenas a listagem de tickets novos opera corretamente, enquanto outras funcionalidades quebram com frequência e são difíceis de manter.
+
+## Objetivo do diretório `refatorado/glpi_dashboard`
+Criar uma base documental completa antes de qualquer reescrita de código, definindo:
+
+- visão arquitetural consolidada para backend, frontend e pipelines de dados;
+- contratos bem especificados entre camadas (GLPI API ⇄ Ingestão ⇄ Backend ⇄ Frontend);
+- padrões de projeto, metodologias e guardrails de qualidade para impedir novas dívidas técnicas;
+- roteiro de implementação incremental garantindo preservação das consultas `criteria` do GLPI.
+
+Todo o código futuro deverá nascer seguindo estas diretrizes, sem reutilizar automaticamente artefatos legados que não passem pela validação descrita aqui.
+
+## Estrutura da Documentação
+1. [01_Principios_Arquitetura.md](01_Principios_Arquitetura.md) — Valores, padrões e heurísticas de decisão.
+2. [02_Estrutura_Pastas.md](02_Estrutura_Pastas.md) — Layout de diretórios para aplicações e pacotes compartilhados.
+3. [03_Contratos_Backend.md](03_Contratos_Backend.md) — Interfaces, casos de uso e integrações GLPI.
+4. [04_Contratos_Frontend.md](04_Contratos_Frontend.md) — Componentização, estado, consumo de métricas.
+5. [05_Governanca_Qualidade.md](05_Governanca_Qualidade.md) — Automação, testes, observabilidade e compliance.
+6. [06_Roadmap_Implementacao.md](06_Roadmap_Implementacao.md) — Sequência tática para construir o produto refatorado.
+
+Cada documento é versionado e deve ser atualizado antes de qualquer mudança estrutural no código, mantendo este diretório como a **fonte da verdade**.
+
+## Como usar
+1. **Leitura obrigatória** para todo colaborador antes de tocar no código.
+2. **Processo de RFC**: propostas de alteração devem referenciar seções específicas deste diretório e só podem ser aceitas após revisão de arquitetura.
+3. **Checklist de implementação**: cada epics/tarefa só inicia quando os critérios das seções relevantes estiverem marcados como atendidos.
+
+## Próximos passos
+- Validar coletivamente os documentos e ajustar conforme feedback do time.
+- Bloquear merges que não façam referência explícita às diretrizes desta pasta.
+- Iniciar execução do roadmap seguindo a ordem definida em `06_Roadmap_Implementacao.md`.


### PR DESCRIPTION
## Summary
- documentar a validação da completude dos guias arquiteturais e roadmap
- adicionar prompt orquestrador que alinha agentes com cada documento da refatoração

## Testing
- not run (documentação)

------
https://chatgpt.com/codex/tasks/task_e_68c8d92a5df0832082e260ea0218e051